### PR TITLE
Fix libvartypes case.

### DIFF
--- a/Simulator.pro
+++ b/Simulator.pro
@@ -64,7 +64,7 @@ HEADERS += mainwindow.h \
 LIBS += -L$$PWD/libs/ \
     -lode \
     -lprotobuf \
-    -lVarTypes
+    -lvartypes
 MOC_DIR = $$PWD/objs
 OBJECTS_DIR = $$PWD/objs
 DESTDIR = $$PWD/bin


### PR DESCRIPTION
The VarTypes build system actually generates a library called "libvartypes.so", not "libVarTypes.so". This commit changes Simulator.pro to refer to the correct filename.
