### PR TITLE
Fix INSTALL instructions.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -8,6 +8,6 @@ To Install grSim on your system follow these steps:
 2. cd proto/pb
    protoc *.proto --cpp_out=../
    
-3. qmake grSim.pro
+3. qmake Simulator.pro
 
 4. make


### PR DESCRIPTION
The INSTALL instructions refer to the file "grSim.pro". This file does not exist; it's actually called "Simulator.pro". This commit fixes the instructions.
