### PR TITLE
Use pkg-config to find protobuf library for client

### DIFF
--- a/client/qt/client.pro
+++ b/client/qt/client.pro
@@ -19,4 +19,4 @@ SOURCES += main.cpp\
 
 HEADERS  += mainwindow.h
 INCLUDEPATH += ../include
-LIBS += -L../libs/ -lprotobuf-2.4.0
+LIBS += -L../libs/ `pkg-config protobuf --libs`


### PR DESCRIPTION
The QT project file for the client currently hardcodes "-lprotobuf-2.4.0". It should use pkg-config instead. This patch changes it appropriately.
