### PR TITLE
Fix spelling: fiction -> friction

### DIFF
--- a/config/Parsian.ini
+++ b/config/Parsian.ini
@@ -20,8 +20,8 @@ Kickermass =0.02
 KickerDampFactor = 0.2
 RollerTorqueFactor = 0.06
 RollerPerpendicularTorqueFactor = 0.005
-KickerFiction = 0.8
-WheelTangentFiction = 0.8
-WheelPerpendicularFiction = 0.05
+KickerFriction = 0.8
+WheelTangentFriction = 0.8
+WheelPerpendicularFriction = 0.05
 WheelMotorMaximumApplyingTorque= 0.2
 

--- a/config/ParsianNew.ini
+++ b/config/ParsianNew.ini
@@ -20,8 +20,8 @@ Kickermass =0.02
 KickerDampFactor = 0.2
 RollerTorqueFactor = 0.06
 RollerPerpendicularTorqueFactor = 0.005
-KickerFiction = 0.8
-WheelTangentFiction = 0.8
-WheelPerpendicularFiction = 0.05
+KickerFriction = 0.8
+WheelTangentFriction = 0.8
+WheelPerpendicularFriction = 0.05
 WheelMotorMaximumApplyingTorque= 0.2
 

--- a/config/RoboIME2012.ini
+++ b/config/RoboIME2012.ini
@@ -21,8 +21,8 @@ Kickermass = 0.02
 KickerDampFactor = 0.2
 RollerTorqueFactor = 0.06
 RollerPerpendicularTorqueFactor = 0.005
-KickerFiction = 0.8
-WheelTangentFiction = 0.8
-WheelPerpendicularFiction = 0.05
+KickerFriction = 0.8
+WheelTangentFriction = 0.8
+WheelPerpendicularFriction = 0.05
 WheelMotorMaximumApplyingTorque = 0.2
 


### PR DESCRIPTION
Friction is spelled correctly in the code base, but not in the config files meaning only defaults were being used.