### PR TITLE
Add a grSim headless mode

### DIFF
--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -71,6 +71,7 @@ public slots:
     void reconnectBlueStatusSocket();
     void reconnectVisionSocket();
     void recvActions();
+    void setIsGlEnabled(bool value);
 private:
     int getInterval();    
     QTimer *timer;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,11 +21,22 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 
 int main(int argc, char *argv[])
 {
+    char** argend = argc + argv;
+
     QCoreApplication::setOrganizationName("Parsian");
     QCoreApplication::setOrganizationDomain("parsian-robotics.com");
     QCoreApplication::setApplicationName("grSim");
     QApplication a(argc, argv);
     MainWindow w;
-    w.show();
+
+    if (std::find(argv, argend, std::string("--headless")) != argend
+        || std::find(argv, argend, std::string("-H")) != argend) {
+        // enable headless mode
+        w.hide();
+        w.setIsGlEnabled(false);
+    } else {
+        // Run normally
+        w.show();
+    }
     return a.exec();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -529,3 +529,7 @@ void MainWindow::recvActions()
     glwidget->ssl->recvActions();
 }
 
+void MainWindow::setIsGlEnabled(bool value)
+{
+  glwidget->ssl->isGLEnabled = value;
+}


### PR DESCRIPTION
A grSim headless mode would be very nice to have, especially when considering that grSim takes up significant CPU resources on displaying a 3d world.

This headless mode tries to improve performance (and convenience) by hiding the qt window and turning off the openGL window when passed the `-headless` flag.

Please let me know if you think anything could be improved!
