### PR TITLE
Rtts sim listener

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -2,9 +2,10 @@
 #define CONSTANTS_H
 
 
-#define ROBOT_COUNT 11
+// TODO: When this is put at more than 6, textures start behaving weird.
+// At 7 the skybox goes wonky. At 11 the wheels and the skybox show numbers.
+#define ROBOT_COUNT 6
 
 #define MAX_ROBOT_COUNT 12 //dont change
 
 #endif //CONSTANTS_H
-

--- a/include/configwidget.h
+++ b/include/configwidget.h
@@ -115,7 +115,7 @@ class ConfigWidget : public VarTreeView
 
 protected:
   vector<VarPtr> world;
-  VarTreeModel * tmodel;    
+  VarTreeModel * tmodel;
 public:
   VarListPtr geo_vars;
   ConfigWidget();
@@ -154,13 +154,13 @@ public:
   DEF_VALUE(double,Double,BallLinearDamp)
   DEF_VALUE(double,Double,BallAngularDamp)
 
-  DEF_VALUE(bool,Bool,SyncWithGL)
+  DEF_VALUE(bool,Bool,RealtimePhysics)
   DEF_VALUE(double,Double,DesiredFPS)
   DEF_VALUE(double,Double,DeltaTime)
   DEF_VALUE(int,Int,sendGeometryEvery)
   DEF_VALUE(double,Double,Gravity)
-  DEF_VALUE(std::string,String,VisionMulticastAddr)  
-  DEF_VALUE(int,Int,VisionMulticastPort)  
+  DEF_VALUE(std::string,String,VisionMulticastAddr)
+  DEF_VALUE(int,Int,VisionMulticastPort)
   DEF_VALUE(int,Int,CommandListenPort)
   DEF_VALUE(int,Int,BlueStatusSendPort)
   DEF_VALUE(int,Int,YellowStatusSendPort)
@@ -175,9 +175,9 @@ public:
   DEF_VALUE(double,Double,yellow_team_vanishing)
   DEF_VALUE(std::string, String, plotter_addr)
   DEF_VALUE(int, Int, plotter_port)
-  DEF_VALUE(bool, Bool, plotter)  
+  DEF_VALUE(bool, Bool, plotter)
   void loadRobotSettings(QString team);
-public slots:  
+public slots:
   void loadRobotsSettings();
 };
 

--- a/include/configwidget.h
+++ b/include/configwidget.h
@@ -161,6 +161,8 @@ public:
   DEF_VALUE(double,Double,Gravity)
   DEF_VALUE(std::string,String,VisionMulticastAddr)
   DEF_VALUE(int,Int,VisionMulticastPort)
+  DEF_VALUE(std::string,String,RttsMulticastAddr)
+  DEF_VALUE(int,Int,RttsMulticastPort)
   DEF_VALUE(int,Int,CommandListenPort)
   DEF_VALUE(int,Int,BlueStatusSendPort)
   DEF_VALUE(int,Int,YellowStatusSendPort)

--- a/include/glwidget.h
+++ b/include/glwidget.h
@@ -35,6 +35,7 @@ public:
     GLWidget(QWidget *parent,ConfigWidget* _cfg);
     ~GLWidget();
     dReal getFPS();
+    dReal getPhysicsFPS();
     ConfigWidget* cfg;
     SSLWorld* ssl;
     RobotsFomation* forms[6];
@@ -101,6 +102,7 @@ private:
     bool first_time;
     QTime time,rendertimer;
     dReal m_fps;
+    dReal m_physicsfps;
     QPoint lastPos;
 friend class GLWidgetGraphicsView;
 };

--- a/include/glwidget.h
+++ b/include/glwidget.h
@@ -22,6 +22,7 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 #include <QGLWidget>
 #include <QGraphicsView>
 #include <QTime>
+#include <QTimer>
 #include <QMenu>
 
 #include "sslworld.h"
@@ -35,7 +36,7 @@ public:
     GLWidget(QWidget *parent,ConfigWidget* _cfg);
     ~GLWidget();
     dReal getFPS();
-    dReal getPhysicsFPS();
+    dReal getPhysicsSPS();
     ConfigWidget* cfg;
     SSLWorld* ssl;
     RobotsFomation* forms[6];
@@ -78,6 +79,8 @@ public slots:
     void moveBallHere();
     void lockCameraToRobot();
     void lockCameraToBall();
+
+    void updatePhysicsSPS();
 signals:
     void clicked();
     void selectedRobot();
@@ -98,11 +101,12 @@ protected:
 private:
     int state;
     int moving_robot_id,clicked_robot;
-    int frames;
-    bool first_time;
+    int frames, physicsframes;
     QTime time,rendertimer;
+    QTimer physicsfpsupdatetimer;
     dReal m_fps;
-    dReal m_physicsfps;
+    dReal physicssps;
+    dReal physicsaccumulateddt;
     QPoint lastPos;
 friend class GLWidgetGraphicsView;
 };

--- a/include/glwidget.h
+++ b/include/glwidget.h
@@ -37,6 +37,7 @@ public:
     ~GLWidget();
     dReal getFPS();
     dReal getPhysicsSPS();
+    dReal getPhysicsTPS();
     ConfigWidget* cfg;
     SSLWorld* ssl;
     RobotsFomation* forms[6];
@@ -80,7 +81,7 @@ public slots:
     void lockCameraToRobot();
     void lockCameraToBall();
 
-    void updatePhysicsSPS();
+    void updateTimeStatistics();
 signals:
     void clicked();
     void selectedRobot();
@@ -101,12 +102,16 @@ protected:
 private:
     int state;
     int moving_robot_id,clicked_robot;
-    int frames, physicsframes;
-    QTime time,rendertimer;
+    int frames, physicsframecounter;
+    QTime time,physicstimer;
     QTimer physicsfpsupdatetimer;
     dReal m_fps;
+    // How many simulated seconds go in a real second.
     dReal physicssps;
-    dReal physicsaccumulateddt;
+    // How much time is taken each second for rendering.
+    dReal physicstps;
+    dReal physicsddtcounter;
+    dReal physicstimetaken;
     QPoint lastPos;
 friend class GLWidgetGraphicsView;
 };

--- a/include/glwidget.h
+++ b/include/glwidget.h
@@ -37,7 +37,7 @@ public:
     ~GLWidget();
     dReal getFPS();
     dReal getPhysicsSPS();
-    dReal getPhysicsTPS();
+    dReal getPhysicsAverageStepTime();
     ConfigWidget* cfg;
     SSLWorld* ssl;
     RobotsFomation* forms[6];
@@ -108,8 +108,7 @@ private:
     dReal m_fps;
     // How many simulated seconds go in a real second.
     dReal physicssps;
-    // How much time is taken each second for rendering.
-    dReal physicstps;
+    dReal physicsaveragesteptime;
     dReal physicsddtcounter;
     dReal physicstimetaken;
     QPoint lastPos;

--- a/include/glwidget.h
+++ b/include/glwidget.h
@@ -35,7 +35,7 @@ public:
     GLWidget(QWidget *parent,ConfigWidget* _cfg);
     ~GLWidget();
     dReal getFPS();
-    ConfigWidget* cfg;   
+    ConfigWidget* cfg;
     SSLWorld* ssl;
     RobotsFomation* forms[6];
     QMenu* robpopup,*ballpopup,*mainpopup;
@@ -43,7 +43,7 @@ public:
     QAction* moveRobotAct;
     QAction* selectRobotAct;
     QAction* resetRobotAct;
-    QAction* moveBallAct;        
+    QAction* moveBallAct;
     QAction* lockToBallAct;
     QAction* onOffRobotAct;
     QAction* lockToRobotAct;
@@ -59,13 +59,13 @@ public:
     bool fullScreen;
     void update3DCursor(int mouse_x,int mouse_y);
     void putBall(dReal x,dReal y);
-    void reform(int team,const QString& act);    
+    void reform(int team,const QString& act);
     void step();
 public slots:
     void moveRobot();
     void resetRobot();
     void selectRobot();
-    void unselectRobot();    
+    void unselectRobot();
     void moveCurrentRobot();
     void resetCurrentRobot();
     void moveBall();
@@ -85,15 +85,15 @@ signals:
     void robotTurnedOnOff(int,bool);
 protected:
     void paintGL ();
-    void initializeGL ();        
+    void initializeGL ();
 
     void mousePressEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
-    void mouseReleaseEvent(QMouseEvent *event);    
+    void mouseReleaseEvent(QMouseEvent *event);
     void wheelEvent(QWheelEvent *event);
     void keyPressEvent(QKeyEvent *event);
     void keyReleaseEvent(QKeyEvent* event);
-    void closeEvent(QCloseEvent *event);    
+    void closeEvent(QCloseEvent *event);
 private:
     int state;
     int moving_robot_id,clicked_robot;
@@ -105,7 +105,7 @@ private:
 friend class GLWidgetGraphicsView;
 };
 
-class GLWidgetGraphicsView : public QGraphicsView        
+class GLWidgetGraphicsView : public QGraphicsView
 {
     private:
         GLWidget *glwidget;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -70,6 +70,7 @@ public slots:
     void reconnectYellowStatusSocket();
     void reconnectBlueStatusSocket();
     void reconnectVisionSocket();
+    void reconnectRttsSocket();
     void recvActions();
 private:
     int getInterval();
@@ -96,6 +97,7 @@ private:
     GLWidgetGraphicsView *view;
     QSize lastSize;
     RoboCupSSLServer *visionServer;
+    RoboCupSSLServer *rttsServer;
     QUdpSocket *commandSocket;
     QUdpSocket *blueStatusSocket,*yellowStatusSocket;
 };

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -89,7 +89,7 @@ private:
 
     QAction *showsimulator, *showconfig;
     QAction* fullScreenAct;
-    QLabel *physicsspslabel, *fpslabel,*cursorlabel,*selectinglabel,*vanishlabel,*noiselabel;
+    QLabel *physicsspslabel, *physicstpslabel, *fpslabel,*cursorlabel,*selectinglabel,*vanishlabel,*noiselabel;
     QString current_dir;
 
     QGraphicsScene *scene;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -42,7 +42,7 @@ class MainWindow : public QMainWindow
 
 public:
     MainWindow(QWidget *parent = 0);
-    ~MainWindow();    
+    ~MainWindow();
 public slots:
     void update();
     void updateRobotLabel();
@@ -51,8 +51,8 @@ public slots:
     void changeCurrentRobot();
     void changeCurrentTeam();
 
-    void changeBallMass();   
-    void changeBallGroundSurface();    
+    void changeBallMass();
+    void changeBallGroundSurface();
     void changeBallDamping();
     void changeGravity();
     void changeTimer();
@@ -72,7 +72,7 @@ public slots:
     void reconnectVisionSocket();
     void recvActions();
 private:
-    int getInterval();    
+    int getInterval();
     QTimer *timer;
 #ifndef QT5
     QWorkspace* workspace;
@@ -82,14 +82,14 @@ private:
     GLWidget *glwidget;
     ConfigWidget *configwidget;
     ConfigDockWidget *dockconfig;
-    RobotWidget *robotwidget;        
+    RobotWidget *robotwidget;
 
     CStatusPrinter *printer;
     CStatusWidget *statusWidget;
 
     QAction *showsimulator, *showconfig;
     QAction* fullScreenAct;
-    QLabel *fpslabel,*cursorlabel,*selectinglabel,*vanishlabel,*noiselabel;
+    QLabel *physicsfpslabel, *fpslabel,*cursorlabel,*selectinglabel,*vanishlabel,*noiselabel;
     QString current_dir;
 
     QGraphicsScene *scene;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -89,7 +89,7 @@ private:
 
     QAction *showsimulator, *showconfig;
     QAction* fullScreenAct;
-    QLabel *physicsspslabel, *physicstpslabel, *fpslabel,*cursorlabel,*selectinglabel,*vanishlabel,*noiselabel;
+    QLabel *physicsspslabel, *physicsaveragesteptimelabel, *fpslabel,*cursorlabel,*selectinglabel,*vanishlabel,*noiselabel;
     QString current_dir;
 
     QGraphicsScene *scene;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -89,7 +89,7 @@ private:
 
     QAction *showsimulator, *showconfig;
     QAction* fullScreenAct;
-    QLabel *physicsfpslabel, *fpslabel,*cursorlabel,*selectinglabel,*vanishlabel,*noiselabel;
+    QLabel *physicsspslabel, *fpslabel,*cursorlabel,*selectinglabel,*vanishlabel,*noiselabel;
     QString current_dir;
 
     QGraphicsScene *scene;

--- a/include/robot.h
+++ b/include/robot.h
@@ -66,9 +66,16 @@ public:
         bool kicking;
         int rolling;
         int kickstate;
+
+	// Angle of the kicker with respect to the robot in radians
+	// 0 radians makes the kicker shoot straight
+	dReal angle;
+
         dReal m_kickspeed,m_kicktime;
       public:
         Kicker(Robot* robot);
+	void rotate(dReal angle);
+	void rotateAbsolute(dReal angle);
         void step();
         void kick(dReal kickspeedx, dReal kickspeedz);
         void setRoller(int roller);

--- a/include/sslworld.h
+++ b/include/sslworld.h
@@ -86,6 +86,7 @@ public:
     dReal cursor_x,cursor_y,cursor_z;
     dReal cursor_radius;
     RoboCupSSLServer *visionServer;
+    RoboCupSSLServer *rttsServer;
     QUdpSocket *commandSocket;
     QUdpSocket *blueStatusSocket,*yellowStatusSocket;
     bool updatedCursor;

--- a/src/configwidget.cpp
+++ b/src/configwidget.cpp
@@ -101,6 +101,8 @@ ConfigWidget::ConfigWidget()
   world.push_back(comm_vars);
     ADD_VALUE(comm_vars,String,VisionMulticastAddr,"224.5.23.2","Vision multicast address")  //SSL Vision: "224.5.23.2"
     ADD_VALUE(comm_vars,Int,VisionMulticastPort,10020,"Vision multicast port")
+    ADD_VALUE(comm_vars,String,RttsMulticastAddr,"224.5.23.2","Rtts multicast address")
+    ADD_VALUE(comm_vars,Int,RttsMulticastPort,-1,"Rtts multicast port")
     ADD_VALUE(comm_vars,Int,CommandListenPort,20011,"Command listen port")
     ADD_VALUE(comm_vars,Int,BlueStatusSendPort,30011,"Blue Team status send port")
     ADD_VALUE(comm_vars,Int,YellowStatusSendPort,30012,"Yellow Team status send port")

--- a/src/configwidget.cpp
+++ b/src/configwidget.cpp
@@ -46,11 +46,11 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 
 
 ConfigWidget::ConfigWidget()
-{      
+{
   tmodel=new VarTreeModel();
-  this->setModel(tmodel);  
+  this->setModel(tmodel);
   geo_vars = VarListPtr(new VarList("Geometry"));
-  world.push_back(geo_vars);  
+  world.push_back(geo_vars);
   robot_settings = new QSettings;
     VarListPtr field_vars(new VarList("Field"));
 
@@ -83,7 +83,7 @@ ConfigWidget::ConfigWidget()
   VarListPtr phys_vars(new VarList("Physics"));
   world.push_back(phys_vars);
     VarListPtr worldp_vars(new VarList("World"));
-    phys_vars->addChild(worldp_vars);  
+    phys_vars->addChild(worldp_vars);
         ADD_VALUE(worldp_vars,Double,DesiredFPS,65,"Desired FPS")
         ADD_VALUE(worldp_vars,Bool,SyncWithGL,false,"Synchronize ODE with OpenGL")
         ADD_VALUE(worldp_vars,Double,DeltaTime,0.016,"ODE time step")
@@ -176,7 +176,7 @@ ConfigWidget::ConfigWidget()
   loadRobotsSettings();
 }
 
-ConfigWidget::~ConfigWidget() {  
+ConfigWidget::~ConfigWidget() {
    VarXML::write(world,(QDir::homePath() + QString("/.grsim.xml")).toStdString());
 }
 
@@ -185,7 +185,7 @@ ConfigDockWidget::ConfigDockWidget(QWidget* _parent,ConfigWidget* _conf){
     parent=_parent;conf=_conf;
     setWidget(conf);
     conf->move(0,20);
-}  
+}
 void ConfigDockWidget::closeEvent(QCloseEvent* event)
 {
     emit closeSignal(false);

--- a/src/configwidget.cpp
+++ b/src/configwidget.cpp
@@ -85,7 +85,7 @@ ConfigWidget::ConfigWidget()
     VarListPtr worldp_vars(new VarList("World"));
     phys_vars->addChild(worldp_vars);
         ADD_VALUE(worldp_vars,Double,DesiredFPS,65,"Desired FPS")
-        ADD_VALUE(worldp_vars,Bool,SyncWithGL,false,"Synchronize ODE with OpenGL")
+        ADD_VALUE(worldp_vars,Bool,RealtimePhysics,false,"Realtime physics")
         ADD_VALUE(worldp_vars,Double,DeltaTime,0.016,"ODE time step")
         ADD_VALUE(worldp_vars,Double,Gravity,9.8,"Gravity")
   VarListPtr ballp_vars(new VarList("Ball"));

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -363,6 +363,14 @@ void GLWidget::step()
     ballSpeed  = sqrt(ballSpeed);
     lastBallSpeed = ballSpeed;
 
+    // Restarts the time as well as gets it.
+    // It is important that both getting and resetting happens here, instead
+    // of the resetting happening after the simulation step.
+    // Resetting here will take into account the time it takes to simulate a
+    // step plus the time between steps.
+    // Resetting afterwards will only take into account the time between steps.
+    dReal ddt=rendertimer.restart()/1000.0;
+
     m_fps = frames /(time.elapsed()/1000.0);
     if (!(frames % ((int)(ceil(cfg->DesiredFPS()))))) {
         time.restart();
@@ -371,7 +379,6 @@ void GLWidget::step()
 
     if (cfg->SyncWithGL())
     {
-        dReal ddt=rendertimer.elapsed()/1000.0;
         if (ddt>0.05) ddt=0.05;
         ssl->step(ddt);
         physicsaccumulateddt += ddt;
@@ -381,7 +388,6 @@ void GLWidget::step()
         physicsaccumulateddt += cfg->DeltaTime();
     }
 
-    rendertimer.restart();
     physicsframes++;
     frames ++;
 }

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -372,7 +372,6 @@ void GLWidget::step()
     if (cfg->SyncWithGL())
     {
         dReal ddt=rendertimer.elapsed()/1000.0;
-        std::cout << 1.0 / ddt << "\n";
         if (ddt>0.05) ddt=0.05;
         ssl->step(ddt);
         physicsaccumulateddt += ddt;

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -383,7 +383,7 @@ void GLWidget::step()
         frames = 0;
     }
 
-    if (cfg->SyncWithGL())
+    if (cfg->RealtimePhysics())
     {
         if (ddt>0.05) ddt=0.05;
         ssl->step(ddt);

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -350,9 +350,9 @@ dReal GLWidget::getPhysicsSPS()
     return physicssps;
 }
 
-dReal GLWidget::getPhysicsTPS()
+dReal GLWidget::getPhysicsAverageStepTime()
 {
-    return physicstps;
+    return physicsaveragesteptime;
 }
 
 
@@ -622,7 +622,7 @@ void GLWidget::moveRobotHere()
 void GLWidget::updateTimeStatistics()
 {
     physicssps = physicsddtcounter;
-    physicstps = physicstimetaken/1000.0;
+    physicsaveragesteptime = physicstimetaken / physicsframecounter;
     physicstimetaken = 0;
     physicsframecounter = 0;
     physicsddtcounter = 0;

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -340,6 +340,11 @@ dReal GLWidget::getFPS()
     return m_fps;
 }
 
+dReal GLWidget::getPhysicsFPS()
+{
+    return m_physicsfps;
+}
+
 
 void GLWidget::initializeGL ()
 {
@@ -359,18 +364,22 @@ void GLWidget::step()
         time.restart();
         frames = 0;
     }
-    //if (first_time) {ssl->step();first_time = false;}
-    //else {
-    if (cfg->SyncWithGL())
-    {
-        dReal ddt=rendertimer.elapsed()/1000.0;
-        if (ddt>0.05) ddt=0.05;
-        ssl->step(ddt);
-    }
+    if (first_time) {ssl->step();first_time = false;}
     else {
-        ssl->step(cfg->DeltaTime());
+        if (cfg->SyncWithGL())
+        {
+            dReal ddt=rendertimer.elapsed()/1000.0;
+            if (ddt>0.05) ddt=0.05;
+            ssl->step(ddt);
+            m_physicsfps = 1.0/ddt;
+        }
+        else {
+            ssl->step(cfg->DeltaTime());
+            // TODO: This is not really the fps.
+            // but a fixed number.
+            m_physicsfps = 1.0/cfg->DeltaTime();
+        }
     }
-    //}
 
     rendertimer.restart();
     frames ++;

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -502,8 +502,8 @@ void GLWidget::keyPressEvent(QKeyEvent *event)
     case 'g': case 'G': ssl->robots[R]->incSpeed(0,S);ssl->robots[R]->incSpeed(1,-S);ssl->robots[R]->incSpeed(2,S);ssl->robots[R]->incSpeed(3,-S);break;
     case 'f': case 'F': ssl->robots[R]->incSpeed(0,S);ssl->robots[R]->incSpeed(1,S);ssl->robots[R]->incSpeed(2,S);ssl->robots[R]->incSpeed(3,S);break;
     case 'h': case 'H': ssl->robots[R]->incSpeed(0,-S);ssl->robots[R]->incSpeed(1,-S);ssl->robots[R]->incSpeed(2,-S);ssl->robots[R]->incSpeed(3,-S);break;
-    case 'r': case 'R': ssl->robots[R]->kicker->rotate(-M_PI/20);break;
-    case 'y': case 'Y': ssl->robots[R]->kicker->rotate(M_PI/20);break;
+    case 'r': case 'R': ssl->robots[R]->kicker->rotate(-2*M_PI/40);break;
+    case 'y': case 'Y': ssl->robots[R]->kicker->rotate(2*M_PI/40);break;
     case 'w': case 'W':dBodyAddForce(ssl->ball->body,0, BallForce,0);break;
     case 's': case 'S':dBodyAddForce(ssl->ball->body,0,-BallForce,0);break;
     case 'd': case 'D':dBodyAddForce(ssl->ball->body, BallForce,0,0);break;

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -502,8 +502,8 @@ void GLWidget::keyPressEvent(QKeyEvent *event)
     case 'g': case 'G': ssl->robots[R]->incSpeed(0,S);ssl->robots[R]->incSpeed(1,-S);ssl->robots[R]->incSpeed(2,S);ssl->robots[R]->incSpeed(3,-S);break;
     case 'f': case 'F': ssl->robots[R]->incSpeed(0,S);ssl->robots[R]->incSpeed(1,S);ssl->robots[R]->incSpeed(2,S);ssl->robots[R]->incSpeed(3,S);break;
     case 'h': case 'H': ssl->robots[R]->incSpeed(0,-S);ssl->robots[R]->incSpeed(1,-S);ssl->robots[R]->incSpeed(2,-S);ssl->robots[R]->incSpeed(3,-S);break;
-    case 'r': case 'R': ssl->robots[R]->kicker->rotate(-2*M_PI/40);break;
-    case 'y': case 'Y': ssl->robots[R]->kicker->rotate(2*M_PI/40);break;
+    case 'r': case 'R': ssl->robots[R]->kicker->rotate(-2*M_PI/360*10);break;
+    case 'y': case 'Y': ssl->robots[R]->kicker->rotate(2*M_PI/360*10);break;
     case 'w': case 'W':dBodyAddForce(ssl->ball->body,0, BallForce,0);break;
     case 's': case 'S':dBodyAddForce(ssl->ball->body,0,-BallForce,0);break;
     case 'd': case 'D':dBodyAddForce(ssl->ball->body, BallForce,0,0);break;

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -502,6 +502,8 @@ void GLWidget::keyPressEvent(QKeyEvent *event)
     case 'g': case 'G': ssl->robots[R]->incSpeed(0,S);ssl->robots[R]->incSpeed(1,-S);ssl->robots[R]->incSpeed(2,S);ssl->robots[R]->incSpeed(3,-S);break;
     case 'f': case 'F': ssl->robots[R]->incSpeed(0,S);ssl->robots[R]->incSpeed(1,S);ssl->robots[R]->incSpeed(2,S);ssl->robots[R]->incSpeed(3,S);break;
     case 'h': case 'H': ssl->robots[R]->incSpeed(0,-S);ssl->robots[R]->incSpeed(1,-S);ssl->robots[R]->incSpeed(2,-S);ssl->robots[R]->incSpeed(3,-S);break;
+    case 'r': case 'R': ssl->robots[R]->kicker->rotate(-M_PI/20);break;
+    case 'y': case 'Y': ssl->robots[R]->kicker->rotate(M_PI/20);break;
     case 'w': case 'W':dBodyAddForce(ssl->ball->body,0, BallForce,0);break;
     case 's': case 'S':dBodyAddForce(ssl->ball->body,0,-BallForce,0);break;
     case 'd': case 'D':dBodyAddForce(ssl->ball->body, BallForce,0,0);break;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -98,20 +98,20 @@ MainWindow::MainWindow(QWidget *parent)
 
     robotwidget = new RobotWidget(this);
     /* Status Bar */
-    physicsfpslabel = new QLabel(this);
+    physicsspslabel = new QLabel(this);
     fpslabel = new QLabel(this);
     cursorlabel = new QLabel(this);
     selectinglabel = new QLabel(this);
     vanishlabel = new QLabel("Vanishing",this);
     noiselabel = new QLabel("Gaussian noise",this);
     fpslabel->setFrameStyle(QFrame::Panel);
-    physicsfpslabel->setFrameStyle(QFrame::Panel);
+    physicsspslabel->setFrameStyle(QFrame::Panel);
     cursorlabel->setFrameStyle(QFrame::Panel);
     selectinglabel->setFrameStyle(QFrame::Panel);
     vanishlabel->setFrameStyle(QFrame::Panel);
     noiselabel->setFrameStyle(QFrame::Panel);
     statusBar()->addWidget(fpslabel);
-    statusBar()->addWidget(physicsfpslabel);
+    statusBar()->addWidget(physicsspslabel);
     statusBar()->addWidget(cursorlabel);
     statusBar()->addWidget(selectinglabel);
     statusBar()->addWidget(vanishlabel);
@@ -322,7 +322,7 @@ void MainWindow::update()
     lvv[2]=vv[2];
     QString ss;
     fpslabel->setText(QString("Frame rate: %1 fps").arg(ss.sprintf("%06.2f", glwidget->getFPS())));
-    physicsfpslabel->setText(QString("Physics rate: %1 fps. DONT THRUST THIS").arg(ss.sprintf("%06.2f", glwidget->getPhysicsFPS())));
+    physicsspslabel->setText(QString("Physics realtimeness: %1 sps").arg(ss.sprintf("%03.2f", glwidget->getPhysicsSPS())));
     if (glwidget->ssl->selected!=-1)
     {
         selectinglabel->setVisible(true);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -81,15 +81,18 @@ MainWindow::MainWindow(QWidget *parent)
     glwidget->resize(512,512);
 
     visionServer = NULL;
+    rttsServer = NULL;
     commandSocket = NULL;
     blueStatusSocket = NULL;
     yellowStatusSocket = NULL;
     reconnectVisionSocket();
+    reconnectRttsSocket();
     reconnectCommandSocket();
     reconnectBlueStatusSocket();
     reconnectYellowStatusSocket();
 
     glwidget->ssl->visionServer = visionServer;
+    glwidget->ssl->rttsServer = rttsServer;
     glwidget->ssl->commandSocket = commandSocket;
     glwidget->ssl->blueStatusSocket = blueStatusSocket;
     glwidget->ssl->yellowStatusSocket = yellowStatusSocket;
@@ -239,6 +242,8 @@ MainWindow::MainWindow(QWidget *parent)
     //network
     QObject::connect(configwidget->v_VisionMulticastAddr.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectVisionSocket()));
     QObject::connect(configwidget->v_VisionMulticastPort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectVisionSocket()));
+    QObject::connect(configwidget->v_RttsMulticastAddr.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectRttsSocket()));
+    QObject::connect(configwidget->v_RttsMulticastPort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectRttsSocket()));
     QObject::connect(configwidget->v_CommandListenPort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectCommandSocket()));
     QObject::connect(configwidget->v_BlueStatusSendPort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectBlueStatusSocket()));
     QObject::connect(configwidget->v_YellowStatusSendPort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectYellowStatusSocket()));
@@ -389,6 +394,7 @@ void MainWindow::restartSimulator()
     glwidget->ssl = new SSLWorld(glwidget,glwidget->cfg,glwidget->forms[2],glwidget->forms[2]);
     glwidget->ssl->glinit();
     glwidget->ssl->visionServer = visionServer;
+    glwidget->ssl->rttsServer = rttsServer;
     glwidget->ssl->commandSocket = commandSocket;
     glwidget->ssl->blueStatusSocket = blueStatusSocket;
     glwidget->ssl->yellowStatusSocket = yellowStatusSocket;
@@ -522,6 +528,18 @@ void MainWindow::reconnectVisionSocket()
     visionServer->change_address(configwidget->VisionMulticastAddr());
     visionServer->change_port(configwidget->VisionMulticastPort());
     logStatus(QString("Vision server connected on: %1").arg(configwidget->VisionMulticastPort()),QColor("green"));
+}
+
+void MainWindow::reconnectRttsSocket()
+{
+    if(configwidget->RttsMulticastPort() != -1){
+        if (rttsServer == NULL) {
+            rttsServer = new RoboCupSSLServer(this);
+        }
+        rttsServer->change_address(configwidget->RttsMulticastAddr());
+        rttsServer->change_port(configwidget->RttsMulticastPort());
+        logStatus(QString("Rtts server connected on: %1").arg(configwidget->VisionMulticastPort()),QColor("green"));
+    }
 }
 
 void MainWindow::recvActions()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -99,7 +99,7 @@ MainWindow::MainWindow(QWidget *parent)
     robotwidget = new RobotWidget(this);
     /* Status Bar */
     physicsspslabel = new QLabel(this);
-    physicstpslabel = new QLabel(this);
+    physicsaveragesteptimelabel = new QLabel(this);
     fpslabel = new QLabel(this);
     cursorlabel = new QLabel(this);
     selectinglabel = new QLabel(this);
@@ -107,14 +107,14 @@ MainWindow::MainWindow(QWidget *parent)
     noiselabel = new QLabel("Gaussian noise",this);
     fpslabel->setFrameStyle(QFrame::Panel);
     physicsspslabel->setFrameStyle(QFrame::Panel);
-    physicstpslabel->setFrameStyle(QFrame::Panel);
+    physicsaveragesteptimelabel->setFrameStyle(QFrame::Panel);
     cursorlabel->setFrameStyle(QFrame::Panel);
     selectinglabel->setFrameStyle(QFrame::Panel);
     vanishlabel->setFrameStyle(QFrame::Panel);
     noiselabel->setFrameStyle(QFrame::Panel);
     statusBar()->addWidget(fpslabel);
     statusBar()->addWidget(physicsspslabel);
-    statusBar()->addWidget(physicstpslabel);
+    statusBar()->addWidget(physicsaveragesteptimelabel);
     statusBar()->addWidget(cursorlabel);
     statusBar()->addWidget(selectinglabel);
     statusBar()->addWidget(vanishlabel);
@@ -326,7 +326,7 @@ void MainWindow::update()
     QString ss;
     fpslabel->setText(QString("Frame rate: %1 fps").arg(ss.sprintf("%06.2f", glwidget->getFPS())));
     physicsspslabel->setText(QString("Physics realtimeness: %1 sps").arg(ss.sprintf("%03.2f", glwidget->getPhysicsSPS())));
-    physicstpslabel->setText(QString("Simulation time per second: %1 seconds").arg(ss.sprintf("%03.2f", glwidget->getPhysicsTPS())));
+    physicsaveragesteptimelabel->setText(QString("Average physics step time: %1 ms").arg(ss.sprintf("%03.1f", glwidget->getPhysicsAverageStepTime())));
     if (glwidget->ssl->selected!=-1)
     {
         selectinglabel->setVisible(true);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -324,7 +324,7 @@ void MainWindow::update()
     lvv[1]=vv[1];
     lvv[2]=vv[2];
     QString ss;
-    fpslabel->setText(QString("Frame rate: %1 fps").arg(ss.sprintf("%06.2f", glwidget->getFPS())));
+    fpslabel->setText(QString("OpenGL / ODE framerate: %1 fps").arg(ss.sprintf("%06.2f", glwidget->getFPS())));
     physicsspslabel->setText(QString("Physics realtimeness: %1 sps").arg(ss.sprintf("%03.2f", glwidget->getPhysicsSPS())));
     physicsaveragesteptimelabel->setText(QString("Average physics step time: %1 ms").arg(ss.sprintf("%03.1f", glwidget->getPhysicsAverageStepTime())));
     if (glwidget->ssl->selected!=-1)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -99,6 +99,7 @@ MainWindow::MainWindow(QWidget *parent)
     robotwidget = new RobotWidget(this);
     /* Status Bar */
     physicsspslabel = new QLabel(this);
+    physicstpslabel = new QLabel(this);
     fpslabel = new QLabel(this);
     cursorlabel = new QLabel(this);
     selectinglabel = new QLabel(this);
@@ -106,12 +107,14 @@ MainWindow::MainWindow(QWidget *parent)
     noiselabel = new QLabel("Gaussian noise",this);
     fpslabel->setFrameStyle(QFrame::Panel);
     physicsspslabel->setFrameStyle(QFrame::Panel);
+    physicstpslabel->setFrameStyle(QFrame::Panel);
     cursorlabel->setFrameStyle(QFrame::Panel);
     selectinglabel->setFrameStyle(QFrame::Panel);
     vanishlabel->setFrameStyle(QFrame::Panel);
     noiselabel->setFrameStyle(QFrame::Panel);
     statusBar()->addWidget(fpslabel);
     statusBar()->addWidget(physicsspslabel);
+    statusBar()->addWidget(physicstpslabel);
     statusBar()->addWidget(cursorlabel);
     statusBar()->addWidget(selectinglabel);
     statusBar()->addWidget(vanishlabel);
@@ -323,6 +326,7 @@ void MainWindow::update()
     QString ss;
     fpslabel->setText(QString("Frame rate: %1 fps").arg(ss.sprintf("%06.2f", glwidget->getFPS())));
     physicsspslabel->setText(QString("Physics realtimeness: %1 sps").arg(ss.sprintf("%03.2f", glwidget->getPhysicsSPS())));
+    physicstpslabel->setText(QString("Simulation time per second: %1 seconds").arg(ss.sprintf("%03.2f", glwidget->getPhysicsTPS())));
     if (glwidget->ssl->selected!=-1)
     {
         selectinglabel->setVisible(true);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -69,7 +69,7 @@ MainWindow::MainWindow(QWidget *parent)
 #else
     workspace = new QWorkspace(this);
 #endif
-    setCentralWidget(workspace);    
+    setCentralWidget(workspace);
 
     /* Widgets */
 
@@ -78,7 +78,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     glwidget = new GLWidget(this,configwidget);
     glwidget->setWindowTitle(tr("Simulator"));
-    glwidget->resize(512,512);    
+    glwidget->resize(512,512);
 
     visionServer = NULL;
     commandSocket = NULL;
@@ -98,17 +98,20 @@ MainWindow::MainWindow(QWidget *parent)
 
     robotwidget = new RobotWidget(this);
     /* Status Bar */
+    physicsfpslabel = new QLabel(this);
     fpslabel = new QLabel(this);
     cursorlabel = new QLabel(this);
     selectinglabel = new QLabel(this);
     vanishlabel = new QLabel("Vanishing",this);
     noiselabel = new QLabel("Gaussian noise",this);
     fpslabel->setFrameStyle(QFrame::Panel);
+    physicsfpslabel->setFrameStyle(QFrame::Panel);
     cursorlabel->setFrameStyle(QFrame::Panel);
     selectinglabel->setFrameStyle(QFrame::Panel);
     vanishlabel->setFrameStyle(QFrame::Panel);
     noiselabel->setFrameStyle(QFrame::Panel);
     statusBar()->addWidget(fpslabel);
+    statusBar()->addWidget(physicsfpslabel);
     statusBar()->addWidget(cursorlabel);
     statusBar()->addWidget(selectinglabel);
     statusBar()->addWidget(vanishlabel);
@@ -116,11 +119,11 @@ MainWindow::MainWindow(QWidget *parent)
     /* Menus */
 
     QMenu *fileMenu = new QMenu("&File");
-    menuBar()->addMenu(fileMenu);    
+    menuBar()->addMenu(fileMenu);
     QAction *takeSnapshotAct = new QAction("&Save snapshot to file", fileMenu);
     takeSnapshotAct->setShortcut(QKeySequence("F3"));
     QAction *takeSnapshotToClipboardAct = new QAction("&Copy snapshot to clipboard", fileMenu);
-    takeSnapshotToClipboardAct->setShortcut(QKeySequence("F4"));    
+    takeSnapshotToClipboardAct->setShortcut(QKeySequence("F4"));
     QAction *exit = new QAction("E&xit", fileMenu);
     exit->setShortcut(QKeySequence("Ctrl+X"));
     fileMenu->addAction(takeSnapshotAct);
@@ -178,7 +181,7 @@ MainWindow::MainWindow(QWidget *parent)
     workspace->addSubWindow(glwidget, Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowMinimizeButtonHint | Qt::WindowMaximizeButtonHint);
 #else
    workspace->addWindow(glwidget, Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowMinimizeButtonHint | Qt::WindowMaximizeButtonHint);
-#endif    
+#endif
 
     glwidget->setWindowState(Qt::WindowMaximized);
 
@@ -192,7 +195,7 @@ MainWindow::MainWindow(QWidget *parent)
     QObject::connect(exit, SIGNAL(triggered(bool)), this, SLOT(close()));
     QObject::connect(showsimulator, SIGNAL(triggered(bool)), this, SLOT(showHideSimulator(bool)));
     QObject::connect(showconfig, SIGNAL(triggered(bool)), this, SLOT(showHideConfig(bool)));
-    QObject::connect(glwidget, SIGNAL(closeSignal(bool)), this, SLOT(showHideSimulator(bool)));    
+    QObject::connect(glwidget, SIGNAL(closeSignal(bool)), this, SLOT(showHideSimulator(bool)));
     QObject::connect(dockconfig, SIGNAL(closeSignal(bool)), this, SLOT(showHideConfig(bool)));
     QObject::connect(glwidget, SIGNAL(selectedRobot()), this, SLOT(updateRobotLabel()));
     QObject::connect(robotwidget->robotCombo,SIGNAL(currentIndexChanged(int)),this,SLOT(changeCurrentRobot()));
@@ -246,7 +249,7 @@ MainWindow::MainWindow(QWidget *parent)
     robotwidget->robotCombo->setCurrentIndex(0);
     robotwidget->setPicture(glwidget->ssl->robots[robotIndex(glwidget->Current_robot,glwidget->Current_team)]->img);
     robotwidget->id = 0;
-    scene = new QGraphicsScene(0,0,800,600);    
+    scene = new QGraphicsScene(0,0,800,600);
 }
 
 MainWindow::~MainWindow()
@@ -267,7 +270,7 @@ void MainWindow::showHideSimulator(bool v)
 
 void MainWindow::changeCurrentRobot()
 {
-    glwidget->Current_robot=robotwidget->robotCombo->currentIndex();    
+    glwidget->Current_robot=robotwidget->robotCombo->currentIndex();
     robotwidget->setPicture(glwidget->ssl->robots[robotIndex(glwidget->Current_robot,glwidget->Current_team)]->img);
     robotwidget->id = robotIndex(glwidget->Current_robot, glwidget->Current_team);
     robotwidget->changeRobotOnOff(robotwidget->id, glwidget->ssl->robots[robotwidget->id]->on);
@@ -318,16 +321,17 @@ void MainWindow::update()
     lvv[1]=vv[1];
     lvv[2]=vv[2];
     QString ss;
-    fpslabel->setText(QString("Frame rate: %1 fps").arg(ss.sprintf("%06.2f",glwidget->getFPS())));        
+    fpslabel->setText(QString("Frame rate: %1 fps").arg(ss.sprintf("%06.2f", glwidget->getFPS())));
+    physicsfpslabel->setText(QString("Physics rate: %1 fps. DONT THRUST THIS").arg(ss.sprintf("%06.2f", glwidget->getPhysicsFPS())));
     if (glwidget->ssl->selected!=-1)
     {
         selectinglabel->setVisible(true);
         if (glwidget->ssl->selected==-2)
-        {            
+        {
             selectinglabel->setText("Ball");
         }
         else
-        {            
+        {
             int R = glwidget->ssl->selected%ROBOT_COUNT;
             int T = glwidget->ssl->selected/ROBOT_COUNT;
             if (T==0) selectinglabel->setText(QString("%1:Blue").arg(R));
@@ -376,7 +380,7 @@ void MainWindow::changeBallDamping()
 }
 
 void MainWindow::restartSimulator()
-{        
+{
     delete glwidget->ssl;
     glwidget->ssl = new SSLWorld(glwidget,glwidget->cfg,glwidget->forms[2],glwidget->forms[2]);
     glwidget->ssl->glinit();
@@ -407,19 +411,19 @@ void MainWindow::toggleFullScreen(bool a)
     if (a)
     {
         view = new GLWidgetGraphicsView(scene,glwidget);
-        lastSize = glwidget->size();        
+        lastSize = glwidget->size();
         view->setViewport(glwidget);
         view->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
         view->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
         view->setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
         view->setFrameStyle(0);
         view->showFullScreen();
-        view->setFocus();        
+        view->setFocus();
         glwidget->fullScreen = true;
         fullScreenAct->setChecked(true);
     }
     else {
-        view->close(); 
+        view->close();
 #ifdef QT5
         workspace->addSubWindow(glwidget, Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowMinimizeButtonHint | Qt::WindowMaximizeButtonHint);
 #else
@@ -520,4 +524,3 @@ void MainWindow::recvActions()
 {
     glwidget->ssl->recvActions();
 }
-

--- a/src/proto/grSim_Commands.proto
+++ b/src/proto/grSim_Commands.proto
@@ -11,6 +11,8 @@ optional float wheel1 = 9;
 optional float wheel2 = 10;
 optional float wheel3 = 11;
 optional float wheel4 = 12;
+// in radians
+required float geneva_angle = 13;
 }
 
 message grSim_Commands {

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -192,7 +192,6 @@ void Robot::Kicker::kick(dReal kickspeedx, dReal kickspeedz)
         dlen = sqrt(dlen);
         vx = dxx*kickspeedx/dlen;
         vy = dyy*kickspeedx/dlen;
-        cout << "Kicker strength: " << sqrt(vx*vx+vy*vy) << endl;
         vz = zf;
         const dReal* vball = dBodyGetLinearVel(rob->getBall()->body);
         dReal vn = -(vball[0]*dxx + vball[1]*dyy)*rob->cfg->robotSettings.KickerDampFactor;

--- a/src/robotwidget.cpp
+++ b/src/robotwidget.cpp
@@ -40,13 +40,6 @@ RobotWidget::RobotWidget(QWidget* parent)
       QString item=QString::number(i);
       robotCombo->addItem(item);
     }
-
-    // robotCombo->addItem("0");
-    // robotCombo->addItem("1");
-    // robotCombo->addItem("2");
-    // robotCombo->addItem("3");
-    // robotCombo->addItem("4");
-    // robotCombo->addItem("5");
     vellabel = new QLabel;
     acclabel = new QLabel;
     resetBtn = new QPushButton("Reset");

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -138,16 +138,16 @@ bool ballCallBack(dGeomID o1,dGeomID o2,PSurface* s)
 
 SSLWorld::SSLWorld(QGLWidget* parent,ConfigWidget* _cfg,RobotsFomation *form1,RobotsFomation *form2)
     : QObject(parent)
-{    
+{
     isGLEnabled = true;
-    customDT = -1;    
+    customDT = -1;
     _w = this;
     cfg = _cfg;
     m_parent = parent;
     show3DCursor = false;
     updatedCursor = false;
     framenum = 0;
-    last_dt = -1;    
+    last_dt = -1;
     g = new CGraphics(parent);
     g->setSphereQuality(1);
     g->setViewpoint(0,-(cfg->Field_Width()+cfg->Field_Margin()*2.0f)/2.0f,3,90,-45,0);
@@ -156,9 +156,9 @@ SSLWorld::SSLWorld(QGLWidget* parent,ConfigWidget* _cfg,RobotsFomation *form1,Ro
 
     ground = new PGround(cfg->Field_Rad(),cfg->Field_Length(),cfg->Field_Width(),cfg->Field_Penalty_Rad(),cfg->Field_Penalty_Line(),cfg->Field_Penalty_Point(),cfg->Field_Line_Width(),cfg->Field_Defense_Stretch(),cfg->Field_Defense_Rad(),0);
     ray = new PRay(50);
-    
+
     // Bounding walls
-    
+
     const double thick = cfg->Wall_Thickness();
     const double increment = cfg->Field_Margin() + cfg->Field_Referee_Margin() + thick / 2;
     const double pos_x = cfg->Field_Length() / 2.0 + increment;
@@ -168,7 +168,7 @@ SSLWorld::SSLWorld(QGLWidget* parent,ConfigWidget* _cfg,RobotsFomation *form1,Ro
     const double siz_y = 2.0 * pos_y;
     const double siz_z = 0.4;
     const double tone = 1.0;
-    
+
     walls[0] = new PFixedBox(thick/2, pos_y, pos_z,
                              siz_x, thick, siz_z,
                              tone, tone, tone);
@@ -176,7 +176,7 @@ SSLWorld::SSLWorld(QGLWidget* parent,ConfigWidget* _cfg,RobotsFomation *form1,Ro
     walls[1] = new PFixedBox(-thick/2, -pos_y, pos_z,
                              siz_x, thick, siz_z,
                              tone, tone, tone);
-    
+
     walls[2] = new PFixedBox(pos_x, -thick/2, pos_z,
                              thick, siz_y, siz_z,
                              tone, tone, tone);
@@ -184,9 +184,9 @@ SSLWorld::SSLWorld(QGLWidget* parent,ConfigWidget* _cfg,RobotsFomation *form1,Ro
     walls[3] = new PFixedBox(-pos_x, thick/2, pos_z,
                              thick, siz_y, siz_z,
                              tone, tone, tone);
-    
+
     // Goal walls
-    
+
     const double gthick = cfg->Goal_Thickness();
     const double gpos_x = (cfg->Field_Length() + gthick) / 2.0 + cfg->Goal_Depth();
     const double gpos_y = (cfg->Goal_Width() + gthick) / 2.0;
@@ -199,11 +199,11 @@ SSLWorld::SSLWorld(QGLWidget* parent,ConfigWidget* _cfg,RobotsFomation *form1,Ro
     walls[4] = new PFixedBox(gpos_x, 0.0, gpos_z,
                              gthick, gsiz_y, gsiz_z,
                              tone, tone, tone);
-    
+
     walls[5] = new PFixedBox(gpos2_x, -gpos_y, gpos_z,
                              gsiz_x, gthick, gsiz_z,
                              tone, tone, tone);
-    
+
     walls[6] = new PFixedBox(gpos2_x, gpos_y, gpos_z,
                              gsiz_x, gthick, gsiz_z,
                              tone, tone, tone);
@@ -211,15 +211,15 @@ SSLWorld::SSLWorld(QGLWidget* parent,ConfigWidget* _cfg,RobotsFomation *form1,Ro
     walls[7] = new PFixedBox(-gpos_x, 0.0, gpos_z,
                              gthick, gsiz_y, gsiz_z,
                              tone, tone, tone);
-    
+
     walls[8] = new PFixedBox(-gpos2_x, -gpos_y, gpos_z,
                              gsiz_x, gthick, gsiz_z,
                              tone, tone, tone);
-    
+
     walls[9] = new PFixedBox(-gpos2_x, gpos_y, gpos_z,
                              gsiz_x, gthick, gsiz_z,
                              tone, tone, tone);
-    
+
     p->addObject(ground);
     p->addObject(ball);
     p->addObject(ray);
@@ -262,10 +262,10 @@ SSLWorld::SSLWorld(QGLWidget* parent,ConfigWidget* _cfg,RobotsFomation *form1,Ro
     ballwithkicker.surface.mode = dContactApprox1;
     ballwithkicker.surface.mu = fric(cfg->robotSettings.Kicker_Friction);
     ballwithkicker.surface.slip1 = 5;
-    
+
     for (int i = 0; i < WALL_COUNT; i++)
         p->createSurface(ball, walls[i])->surface = ballwithwall.surface;
-    
+
     for (int k = 0; k < 2 * ROBOT_COUNT; k++)
     {
         p->createSurface(robots[k]->chassis,ground);
@@ -283,7 +283,7 @@ SSLWorld::SSLWorld(QGLWidget* parent,ConfigWidget* _cfg,RobotsFomation *form1,Ro
             w_g->callback=wheelCallBack;
         }
         for (int j = k + 1; j < 2 * ROBOT_COUNT; j++)
-        {            
+        {
             if (k != j)
             {
                 p->createSurface(robots[k]->dummy,robots[j]->dummy); //seams ode doesn't understand cylinder-cylinder contacts, so I used spheres
@@ -618,9 +618,9 @@ SSL_WrapperPacket* SSLWorld::generatePacket(int cam_id)
 {
     SSL_WrapperPacket* packet = new SSL_WrapperPacket;
     dReal x,y,z,dir;
-    ball->getBodyPosition(x,y,z);    
+    ball->getBodyPosition(x,y,z);
     packet->mutable_detection()->set_camera_id(cam_id);
-    packet->mutable_detection()->set_frame_number(framenum);    
+    packet->mutable_detection()->set_frame_number(framenum);
     dReal t_elapsed = timer->elapsed()/1000.0;
     packet->mutable_detection()->set_t_capture(t_elapsed);
     packet->mutable_detection()->set_t_sent(t_elapsed);
@@ -788,7 +788,7 @@ SendingPacket::SendingPacket(SSL_WrapperPacket* _packet,int _t)
 void SSLWorld::sendVisionBuffer()
 {
     int t = timer->elapsed();
-    sendQueue.push_back(new SendingPacket(generatePacket(0),t));    
+    sendQueue.push_back(new SendingPacket(generatePacket(0),t));
     sendQueue.push_back(new SendingPacket(generatePacket(1),t+1));
     sendQueue.push_back(new SendingPacket(generatePacket(2),t+2));
     sendQueue.push_back(new SendingPacket(generatePacket(3),t+3));

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -520,6 +520,11 @@ void SSLWorld::recvActions()
                         dReal vw = 0;if (packet.commands().robot_commands(i).has_velangular()) vw = packet.commands().robot_commands(i).velangular();
                         robots[id]->setSpeed(vx, vy, vw);
                     }
+                    if (packet.commands().robot_commands(i).has_geneva_angle())
+                    {
+                        // geneva_angle in radians
+                        robots[id]->kicker->rotateAbsolute(packet.commands().robot_commands(i).geneva_angle());
+                    }
                     dReal kickx = 0 , kickz = 0;
                     bool kick = false;
                     if (packet.commands().robot_commands(i).has_kickspeedx())
@@ -540,11 +545,6 @@ void SSLWorld::recvActions()
                         if (packet.commands().robot_commands(i).spinner()) rolling = 1;
                     }
                     robots[id]->kicker->setRoller(rolling);
-                    if (packet.commands().robot_commands(i).has_geneva_angle())
-                    {
-                        // geneva_angle in radians
-                        robots[id]->kicker->rotateAbsolute(packet.commands().robot_commands(i).geneva_angle());
-                    }
                     char status = 0;
                     status = k;
                     if (robots[id]->kicker->isTouchingBall()) status = status | 8;

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -811,6 +811,9 @@ void SSLWorld::sendVisionBuffer()
         delete sendQueue.front();
         sendQueue.pop_front();
         visionServer->send(*packet);
+        if(rttsServer != NULL){
+            rttsServer->send(*packet);
+        }
         delete packet;
         if (sendQueue.isEmpty()) break;
     }

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -540,7 +540,11 @@ void SSLWorld::recvActions()
                         if (packet.commands().robot_commands(i).spinner()) rolling = 1;
                     }
                     robots[id]->kicker->setRoller(rolling);
-
+                    if (packet.commands().robot_commands(i).has_geneva_angle())
+                    {
+                        // geneva_angle in radians
+                        robots[id]->kicker->rotateAbsolute(packet.commands().robot_commands(i).geneva_angle());
+                    }
                     char status = 0;
                     status = k;
                     if (robots[id]->kicker->isTouchingBall()) status = status | 8;


### PR DESCRIPTION
In order to connect the simulator to the front end of the webserver we could either change the port in the simulator and forward all messages to vision (which would cause a lot of unnecessary load on the server) or we could make a little alteration to grSim.

We chose for the second option and the feature can be seen in this branch. An additional RoboCupServer has been added which mimics the behaviour of the visionServer, but instead it will send the data additionally to another port (in our configuration 10037) where one of our python sockets will catch the data, transform it and forward it to the client.

The intention was to make the additional settings (rtts address and rtts port) completely optional. If these are not provided than grSim will ignore them and won't attempt to make an additional connection.

If this is not the actual behaviour than feedback and tips would be much appreciated.