### PR TITLE
Feature switch between division

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -1,9 +1,6 @@
 #ifndef CONSTANTS_H
 #define CONSTANTS_H
 
-
-#define ROBOT_COUNT 8
-
 #define MAX_ROBOT_COUNT 12 //don't change
 
 #endif //CONSTANTS_H

--- a/include/configwidget.h
+++ b/include/configwidget.h
@@ -66,6 +66,11 @@ using namespace VarTypes;
             std::tr1::shared_ptr<VarTypes::Var##Type> v_##name; \
             inline type name() {return v_##name->get##Type();}
 
+#define DEF_FIELD_VALUE(type,Type,name)  \
+            std::tr1::shared_ptr<VarTypes::Var##Type> v_DivA_##name; \
+            std::tr1::shared_ptr<VarTypes::Var##Type> v_DivB_##name; \
+            inline type name() {return (Division() == "Division A" ? v_DivA_##name: v_DivB_##name)->get##Type(); }
+
 #define DEF_ENUM(type,name)  \
             std::tr1::shared_ptr<VarTypes::VarStringEnum> v_##name; \
             type name() {if(v_##name!=NULL) return v_##name->getString();return * (new type);}
@@ -127,21 +132,24 @@ public:
   RobotSettings yellowSettings;
 
   /*    Geometry/Game Vartypes   */
-  DEF_VALUE(double,Double,Field_Line_Width)
-  DEF_VALUE(double,Double,Field_Length)
-  DEF_VALUE(double,Double,Field_Width)
-  DEF_VALUE(double,Double,Field_Rad)
-  DEF_VALUE(double,Double,Field_Free_Kick)
-  DEF_VALUE(double,Double,Field_Penalty_Width)
-  DEF_VALUE(double,Double,Field_Penalty_Depth)
-  DEF_VALUE(double,Double,Field_Penalty_Point)
-  DEF_VALUE(double,Double,Field_Margin)
-  DEF_VALUE(double,Double,Field_Referee_Margin)
-  DEF_VALUE(double,Double,Wall_Thickness)
-  DEF_VALUE(double,Double,Goal_Thickness)
-  DEF_VALUE(double,Double,Goal_Depth)
-  DEF_VALUE(double,Double,Goal_Width)
-  DEF_VALUE(double,Double,Goal_Height)
+  DEF_ENUM(std::string, Division)
+  DEF_VALUE(int, Int, Robots_Count)
+  DEF_FIELD_VALUE(double,Double,Field_Line_Width)
+  DEF_FIELD_VALUE(double,Double,Field_Length)
+  DEF_FIELD_VALUE(double,Double,Field_Width)
+  DEF_FIELD_VALUE(double,Double,Field_Rad)
+  DEF_FIELD_VALUE(double,Double,Field_Free_Kick)
+  DEF_FIELD_VALUE(double,Double,Field_Penalty_Width)
+  DEF_FIELD_VALUE(double,Double,Field_Penalty_Depth)
+  DEF_FIELD_VALUE(double,Double,Field_Penalty_Point)
+  DEF_FIELD_VALUE(double,Double,Field_Margin)
+  DEF_FIELD_VALUE(double,Double,Field_Referee_Margin)
+  DEF_FIELD_VALUE(double,Double,Wall_Thickness)
+  DEF_FIELD_VALUE(double,Double,Goal_Thickness)
+  DEF_FIELD_VALUE(double,Double,Goal_Depth)
+  DEF_FIELD_VALUE(double,Double,Goal_Width)
+  DEF_FIELD_VALUE(double,Double,Goal_Height)
+
   DEF_ENUM(std::string,YellowTeam)
   DEF_ENUM(std::string,BlueTeam)
   DEF_VALUE(double,Double,BallRadius)

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -72,6 +72,8 @@ public slots:
     void reconnectVisionSocket();
     void recvActions();
     void setIsGlEnabled(bool value);
+
+    int robotIndex(int robot,int team);
 private:
     int getInterval();    
     QTimer *timer;

--- a/include/physics/pworld.h
+++ b/include/physics/pworld.h
@@ -34,7 +34,7 @@ private:
     int **sur_matrix;
     int objects_count;
 public:
-    PWorld(dReal dt,dReal gravity,CGraphics* graphics);
+    PWorld(dReal dt,dReal gravity,CGraphics* graphics, int robot_count);
     ~PWorld();
     void setGravity(dReal gravity);
     void addObject(PObject* o);
@@ -48,9 +48,10 @@ public:
     dWorldID world;
     dSpaceID space;
     CGraphics* g;
+    int robot_count;
 };
 
-typedef bool PSurfaceCallback(dGeomID o1,dGeomID o2,PSurface* s);
+typedef bool PSurfaceCallback(dGeomID o1,dGeomID o2,PSurface* s,int robot_count);
 class PSurface
 {
 public:

--- a/include/robotwidget.h
+++ b/include/robotwidget.h
@@ -24,13 +24,14 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 #include <QLabel>
 #include <QPushButton>
 
+#include "configwidget.h"
 #include "getpositionwidget.h"
 
 class RobotWidget : public QDockWidget
 {
     Q_OBJECT
 public:    
-    RobotWidget(QWidget* parent);
+    RobotWidget(QWidget* parent, ConfigWidget* cfg);
     void setPicture(QImage* img);
     QComboBox *teamCombo,*robotCombo;
     QLabel *robotpic;

--- a/include/sslworld.h
+++ b/include/sslworld.h
@@ -74,6 +74,8 @@ public:
     void addFieldArc(SSL_GeometryFieldSize *field, const string &name, float c_x, float c_y, float radius, float a1, float a2, float thickness);
     void sendVisionBuffer();
     bool visibleInCam(int id, double x, double y);
+    int  robotIndex(int robot,int team);
+
     ConfigWidget* cfg;
     CGraphics* g;
     PWorld* p;
@@ -102,10 +104,12 @@ class RobotsFomation {
     public:
         dReal x[MAX_ROBOT_COUNT];
         dReal y[MAX_ROBOT_COUNT];
-        RobotsFomation(int type);
+        RobotsFomation(int type, ConfigWidget* _cfg);
         void setAll(dReal *xx,dReal *yy);
         void loadFromFile(const QString& filename);
         void resetRobots(Robot** r,int team);
+    private:
+        ConfigWidget* cfg;
 };
 
 dReal fric(dReal f);

--- a/src/configwidget.cpp
+++ b/src/configwidget.cpp
@@ -49,27 +49,57 @@ ConfigWidget::ConfigWidget()
   geo_vars = VarListPtr(new VarList("Geometry"));
   world.push_back(geo_vars);  
   robot_settings = new QSettings;
-    VarListPtr field_vars(new VarList("Field"));
-    geo_vars->addChild(field_vars);
-        ADD_VALUE(field_vars,Double,Field_Line_Width,0.010,"Line Thickness")
-        ADD_VALUE(field_vars,Double,Field_Length,9.000,"Length")
-        ADD_VALUE(field_vars,Double,Field_Width,6.000,"Width")
-        ADD_VALUE(field_vars,Double,Field_Rad,0.500,"Radius")
-        ADD_VALUE(field_vars,Double,Field_Free_Kick,0.700,"Free Kick Distanse From Defense Area")
-        ADD_VALUE(field_vars,Double,Field_Penalty_Width,2.40,"Penalty width")
-        ADD_VALUE(field_vars,Double,Field_Penalty_Depth,1.20,"Penalty depth")
-        ADD_VALUE(field_vars,Double,Field_Penalty_Point,1.20,"Penalty point")
-        ADD_VALUE(field_vars,Double,Field_Margin,0.250,"Margin")
-        ADD_VALUE(field_vars,Double,Field_Referee_Margin,0.455,"Referee margin")
-        ADD_VALUE(field_vars,Double,Wall_Thickness,0.050,"Wall thickness")
-        ADD_VALUE(field_vars,Double,Goal_Thickness,0.020,"Goal thickness")
-        ADD_VALUE(field_vars,Double,Goal_Depth,0.200,"Goal depth")
-        ADD_VALUE(field_vars,Double,Goal_Width,1.200,"Goal width")
-        ADD_VALUE(field_vars,Double,Goal_Height,0.160,"Goal height")
-    ADD_ENUM(StringEnum,YellowTeam,"Parsian","Yellow Team");
-    END_ENUM(geo_vars,YellowTeam)
-    ADD_ENUM(StringEnum,BlueTeam,"Parsian","Blue Team");
-    END_ENUM(geo_vars,BlueTeam)
+
+  VarListPtr game_vars(new VarList("Game"));
+  geo_vars->addChild(game_vars);
+  ADD_ENUM(StringEnum, Division, "Division A", "Division")
+  ADD_TO_ENUM(Division, "Division A");
+  ADD_TO_ENUM(Division, "Division B");
+  END_ENUM(game_vars, Division);
+  ADD_VALUE(game_vars,Int, Robots_Count, 8, "Robots Count")
+  VarListPtr fields_vars(new VarList("Field"));
+  VarListPtr div_a_vars(new VarList("Division A"));
+  VarListPtr div_b_vars(new VarList("Division B"));
+  geo_vars->addChild(fields_vars);
+  fields_vars->addChild(div_a_vars);
+  fields_vars->addChild(div_b_vars);
+
+  ADD_VALUE(div_a_vars, Double, DivA_Field_Line_Width,0.010,"Line Thickness")
+  ADD_VALUE(div_a_vars, Double, DivA_Field_Length,12.000,"Length")
+  ADD_VALUE(div_a_vars, Double, DivA_Field_Width,9.000,"Width")
+  ADD_VALUE(div_a_vars, Double, DivA_Field_Rad,0.500,"Radius")
+  ADD_VALUE(div_a_vars, Double, DivA_Field_Free_Kick,0.700,"Free Kick Distance From Defense Area")
+  ADD_VALUE(div_a_vars, Double, DivA_Field_Penalty_Width,2.40,"Penalty width")
+  ADD_VALUE(div_a_vars, Double, DivA_Field_Penalty_Depth,1.20,"Penalty depth")
+  ADD_VALUE(div_a_vars, Double, DivA_Field_Penalty_Point,1.20,"Penalty point")
+  ADD_VALUE(div_a_vars, Double, DivA_Field_Margin,0.3,"Margin")
+  ADD_VALUE(div_a_vars, Double, DivA_Field_Referee_Margin,0.4,"Referee margin")
+  ADD_VALUE(div_a_vars, Double, DivA_Wall_Thickness,0.050,"Wall thickness")
+  ADD_VALUE(div_a_vars, Double, DivA_Goal_Thickness,0.020,"Goal thickness")
+  ADD_VALUE(div_a_vars, Double, DivA_Goal_Depth,0.200,"Goal depth")
+  ADD_VALUE(div_a_vars, Double, DivA_Goal_Width,1.200,"Goal width")
+  ADD_VALUE(div_a_vars, Double, DivA_Goal_Height,0.160,"Goal height")
+
+  ADD_VALUE(div_b_vars, Double, DivB_Field_Line_Width,0.010,"Line Thickness")
+  ADD_VALUE(div_b_vars, Double, DivB_Field_Length,9.000,"Length")
+  ADD_VALUE(div_b_vars, Double, DivB_Field_Width,6.000,"Width")
+  ADD_VALUE(div_b_vars, Double, DivB_Field_Rad,0.500,"Radius")
+  ADD_VALUE(div_b_vars, Double, DivB_Field_Free_Kick,0.700,"Free Kick Distance From Defense Area")
+  ADD_VALUE(div_b_vars, Double, DivB_Field_Penalty_Width,2.00,"Penalty width")
+  ADD_VALUE(div_b_vars, Double, DivB_Field_Penalty_Depth,1.0,"Penalty depth")
+  ADD_VALUE(div_b_vars, Double, DivB_Field_Penalty_Point,1.00,"Penalty point")
+  ADD_VALUE(div_b_vars, Double, DivB_Field_Margin,0.30,"Margin")
+  ADD_VALUE(div_b_vars, Double, DivB_Field_Referee_Margin,0.4,"Referee margin")
+  ADD_VALUE(div_b_vars, Double, DivB_Wall_Thickness,0.050,"Wall thickness")
+  ADD_VALUE(div_b_vars, Double, DivB_Goal_Thickness,0.020,"Goal thickness")
+  ADD_VALUE(div_b_vars, Double, DivB_Goal_Depth,0.200,"Goal depth")
+  ADD_VALUE(div_b_vars, Double, DivB_Goal_Width,1.000,"Goal width")
+  ADD_VALUE(div_b_vars, Double, DivB_Goal_Height,0.160,"Goal height")
+
+  ADD_ENUM(StringEnum,YellowTeam,"Parsian","Yellow Team");
+  END_ENUM(geo_vars,YellowTeam)
+  ADD_ENUM(StringEnum,BlueTeam,"Parsian","Blue Team");
+  END_ENUM(geo_vars,BlueTeam)
 
     VarListPtr ballg_vars(new VarList("Ball"));
     geo_vars->addChild(ballg_vars);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -96,7 +96,7 @@ MainWindow::MainWindow(QWidget *parent)
 
 
 
-    robotwidget = new RobotWidget(this);
+    robotwidget = new RobotWidget(this, configwidget);
     /* Status Bar */
     fpslabel = new QLabel(this);
     cursorlabel = new QLabel(this);
@@ -296,7 +296,7 @@ void MainWindow::showHideSimulator(bool v)
 void MainWindow::changeCurrentRobot()
 {
     glwidget->Current_robot=robotwidget->robotCombo->currentIndex();    
-    robotwidget->setPicture(glwidget->ssl->robots[robotIndex(glwidget->Current_robot,glwidget->Current_team)]->img);
+    robotwidget->setPicture(glwidget->ssl->robots[glwidget->ssl->robotIndex(glwidget->Current_robot,glwidget->Current_team)]->img);
     robotwidget->id = robotIndex(glwidget->Current_robot, glwidget->Current_team);
     robotwidget->changeRobotOnOff(robotwidget->id, glwidget->ssl->robots[robotwidget->id]->on);
 }
@@ -312,6 +312,11 @@ void MainWindow::changeCurrentTeam()
 void MainWindow::changeGravity()
 {
     dWorldSetGravity (glwidget->ssl->p->world,0,0,-configwidget->Gravity());
+}
+
+int MainWindow::robotIndex(int robot,int team)
+{
+    return glwidget->ssl->robotIndex(robot, team);
 }
 
 void MainWindow::changeTimer()
@@ -356,8 +361,8 @@ void MainWindow::update()
         }
         else
         {            
-            int R = glwidget->ssl->selected%ROBOT_COUNT;
-            int T = glwidget->ssl->selected/ROBOT_COUNT;
+            int R = glwidget->ssl->selected%configwidget->Robots_Count();
+            int T = glwidget->ssl->selected/configwidget->Robots_Count();
             if (T==0) selectinglabel->setText(QString("%1:Blue").arg(R));
             else selectinglabel->setText(QString("%1:Yellow").arg(R));
         }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -220,21 +220,41 @@ MainWindow::MainWindow(QWidget *parent)
 
     //geometry config vars
     QObject::connect(configwidget->v_DesiredFPS.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(changeTimer()));
-    QObject::connect(configwidget->v_Field_Line_Width.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
-    QObject::connect(configwidget->v_Field_Length.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
-    QObject::connect(configwidget->v_Field_Width.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
-    QObject::connect(configwidget->v_Field_Rad.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
-    QObject::connect(configwidget->v_Field_Free_Kick.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
-    QObject::connect(configwidget->v_Field_Penalty_Width.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
-    QObject::connect(configwidget->v_Field_Penalty_Depth.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
-    QObject::connect(configwidget->v_Field_Penalty_Point.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
-    QObject::connect(configwidget->v_Field_Margin.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
-    QObject::connect(configwidget->v_Field_Referee_Margin.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
-    QObject::connect(configwidget->v_Wall_Thickness.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
-    QObject::connect(configwidget->v_Goal_Thickness.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
-    QObject::connect(configwidget->v_Goal_Depth.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
-    QObject::connect(configwidget->v_Goal_Width.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
-    QObject::connect(configwidget->v_Goal_Height.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_Division.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_Robots_Count.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+
+    QObject::connect(configwidget->v_DivA_Field_Line_Width.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivA_Field_Length.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivA_Field_Width.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivA_Field_Rad.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivA_Field_Free_Kick.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivA_Field_Penalty_Width.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivA_Field_Penalty_Depth.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivA_Field_Penalty_Point.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivA_Field_Margin.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivA_Field_Referee_Margin.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivA_Wall_Thickness.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivA_Goal_Thickness.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivA_Goal_Depth.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivA_Goal_Width.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivA_Goal_Height.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+
+    QObject::connect(configwidget->v_DivB_Field_Line_Width.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivB_Field_Length.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivB_Field_Width.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivB_Field_Rad.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivB_Field_Free_Kick.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivB_Field_Penalty_Width.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivB_Field_Penalty_Depth.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivB_Field_Penalty_Point.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivB_Field_Margin.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivB_Field_Referee_Margin.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivB_Wall_Thickness.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivB_Goal_Thickness.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivB_Goal_Depth.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivB_Goal_Width.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_DivB_Goal_Height.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+
     QObject::connect(configwidget->v_YellowTeam.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
     QObject::connect(configwidget->v_BlueTeam.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
 

--- a/src/physics/pworld.cpp
+++ b/src/physics/pworld.cpp
@@ -36,8 +36,9 @@ void nearCallback (void *data, dGeomID o1, dGeomID o2)
 }
 
 
-PWorld::PWorld(dReal dt,dReal gravity,CGraphics* graphics)
+PWorld::PWorld(dReal dt,dReal gravity,CGraphics* graphics, int _robot_count)
 {
+    robot_count = _robot_count;
     //dInitODE2(0);
     dInitODE();
     world = dWorldCreate();
@@ -82,7 +83,7 @@ void PWorld::handleCollisions(dGeomID o1, dGeomID o2)
           sur->contactNormal[1] = contact[0].geom.normal[1];
           sur->contactNormal[2] = contact[0].geom.normal[2];
           bool flag=true;
-          if (sur->callback!=NULL) flag = sur->callback(o1,o2,sur);
+          if (sur->callback!=NULL) flag = sur->callback(o1,o2,sur,robot_count);
           if (flag)
           for (int i=0; i<n; i++) {
               contact[i].surface = sur->surface;

--- a/src/robotwidget.cpp
+++ b/src/robotwidget.cpp
@@ -25,7 +25,7 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 #include <QSizePolicy>
 #include <QString>
 
-RobotWidget::RobotWidget(QWidget* parent)
+RobotWidget::RobotWidget(QWidget* parent, ConfigWidget* cfg)
     : QDockWidget("Current Robot",parent)
 {
     QGridLayout *layout = new QGridLayout;
@@ -36,17 +36,11 @@ RobotWidget::RobotWidget(QWidget* parent)
     robotCombo = new QComboBox(this);
 
     // Add items to the combo box dynamically 
-    for (int i=0; i<ROBOT_COUNT; i++){
+    for (int i=0; i<cfg->Robots_Count(); i++){
       QString item=QString::number(i);
       robotCombo->addItem(item);
     }
 
-    // robotCombo->addItem("0");
-    // robotCombo->addItem("1");
-    // robotCombo->addItem("2");
-    // robotCombo->addItem("3");
-    // robotCombo->addItem("4");
-    // robotCombo->addItem("5");
     vellabel = new QLabel;
     acclabel = new QLabel;
     resetBtn = new QPushButton("Reset");


### PR DESCRIPTION
Implement changes for #66 which itself is a follow up on #59 .
- Add field parameter for division A and B. Also, add a parameter to easily switch between the two.
- Add a robots count parameter, which update the number of robot on the field.

The default parameter values should follow the [2018 official rules](http://wiki.robocup.org/images/7/73/Small_Size_League_-_Rules_2018.pdf).