### PR TITLE
Specify qt4 for client

### DIFF
--- a/clients/qt/CMakeLists.txt
+++ b/clients/qt/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(libs)
 
 set(QT_USE_QTNETWORK TRUE)
-find_package(Qt REQUIRED)
+find_package(Qt4 REQUIRED)
 include(${QT_USE_FILE})
 list(APPEND libs ${QT_LIBRARIES})
 


### PR DESCRIPTION
Fixes below issue in newer versions of cmake package that doesn't allow mixing  of qt3/qt4.

`CMake Error at /usr/share/cmake-3.11/Modules/FindQt3.cmake:44 (message):
  Qt3 and Qt4 cannot be used together in one project.
Call Stack (most recent call first):
  /usr/share/cmake-3.11/Modules/FindQt.cmake:151 (include)
  clients/qt/CMakeLists.txt:10 (find_package)
`