### PR TITLE
Fix glviewport scaling on high dpi

### DIFF
--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -394,7 +394,8 @@ void SSLWorld::step(dReal dt)
 
     if (customDT > 0)
         dt = customDT;
-    g->initScene(m_parent->width(),m_parent->height(),0,0.7,1);//true,0.7,0.7,0.7,0.8);
+    const auto ratio = m_parent->devicePixelRatio();
+    g->initScene(m_parent->width()*ratio,m_parent->height()*ratio,0,0.7,1);
     for (int kk=0;kk<5;kk++)
     {
         const dReal* ballvel = dBodyGetLinearVel(ball->body);


### PR DESCRIPTION
### Identify the Bug

#91 

Go from this:
<img width="1792" alt="Screen Shot 2019-08-31 at 7 41 21 PM" src="https://user-images.githubusercontent.com/8744813/64070154-07e9d080-cc29-11e9-9119-4c37cf033eab.png">
<img width="1792" alt="Screen Shot 2019-08-31 at 7 43 00 PM" src="https://user-images.githubusercontent.com/8744813/64070153-05877680-cc29-11e9-94c8-2b313b205198.png">

To this:
<!--

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

Qt supplies a `devicePixelRatio` value to convert from device independent pixels to real screen pixels, this ratio should be used whenever passing values into opengl calls since opengl doesn't work with device independent pixels. (see here for more info: https://doc.qt.io/qt-5/highdpi.html)
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Possible Drawbacks

None?

### Verification Process

Run grSim on a high dpi device

### Release Notes

Added high dpi screen support to OpenGL window.
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Grsim's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

-->