### PR TITLE
Update documents

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,6 @@
 ## Authors
 
-grSim was originally developed by [Ali Koochakzadeh](https://github.com/ali-k) and [Mani Monajjemi](https://mani.im) from [Parsian](http://wiki.robocup.org/Small_Size_League/Teams#Parsian), the RoboCup Small Size Team of [Amirkabir University of Technology](http://www.aut.ac.ir/aut/). Since 2011, it has received numerous contributions from the RoboCup SSL community as well as Parsian team members (listed below). grSim is Currently maintained by [Mohammad Mahdi Rahimi](https://github.com/Mahi97).
+grSim was originally developed by [Ali Koochakzadeh](https://github.com/ali-k) and [Mani Monajjemi](https://mani.im) from [Parsian](https://web.archive.org/web/20190121190441/http://wiki.robocup.org:80/Small_Size_League/Teams#Parsian), the RoboCup Small Size Team of [Amirkabir University of Technology](http://www.aut.ac.ir/aut/). Since 2011, it has received numerous contributions from the RoboCup SSL community as well as Parsian team members (listed below). grSim is Currently maintained by [Mohammad Mahdi Rahimi](https://github.com/Mahi97).
 
 ### Contributers
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,6 @@
 ## Authors
 
-grSim was originally developed by [Ali Koochakzadeh](https://github.com/ali-k) and [Mani Monajjemi](https://mani.im) from [Parsian](https://web.archive.org/web/20190121190441/http://wiki.robocup.org:80/Small_Size_League/Teams#Parsian), the RoboCup Small Size Team of [Amirkabir University of Technology](http://www.aut.ac.ir/aut/). Since 2011, it has received numerous contributions from the RoboCup SSL community as well as Parsian team members (listed below). grSim is Currently maintained by [Mohammad Mahdi Rahimi](https://github.com/Mahi97).
+grSim was originally developed by [Ali Koochakzadeh](https://github.com/ali-k) and [Mani Monajjemi](https://mani.im) from [Parsian](https://github.com/ParsianRoboticLab), the RoboCup Small Size Team of [Amirkabir University of Technology](http://www.aut.ac.ir/aut/). Since 2011, it has received numerous contributions from the RoboCup SSL community as well as Parsian team members (listed below). grSim is Currently maintained by [Mohammad Mahdi Rahimi](https://github.com/Mahi97).
 
 ### Contributers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 grSim is a software from developers for developers, mainly
 in RoboCup Small Size League domain. Commit logs can be
-accessed [here](https://github.com/mani-monaj/grSim/commits/master)
+accessed [here](https://github.com/RoboCup-SSL/grSim/commits/master)
 
 2016-11-05
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@ grSim is a software from developers for developers, mainly
 in RoboCup Small Size League domain. Commit logs can be
 accessed [here](https://github.com/RoboCup-SSL/grSim/commits/master)
 
+2017-01-09
+----------
+
+Mohammad Mahdi Rahimi <mohammadmahdi76@gmail.com>
+
+- Milestone 2.0
+  - Update documentation files
+  - Updates from Parsian
+  - Set explicitly the C++ standard to use : c++03
+  - Enable multi-target build on TravisCI
+  - Use pkg-config for ODE and protobuf
+
 2016-11-05
 ----------
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,7 +45,7 @@ Next, clone grSim into your preferred location.
 
 ```bash
 $ cd /path/to/grsim_ws
-$ git clone https://github.com/mani-monaj/grSim.git
+$ git clone https://github.com/RoboCup-SSL/grSim.git
 $ cd grSim
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ GrSim is written in C++, in order to compile it, you will need a working toolcha
 
 GrSim depends on:
 
-- [CMake](https://cmake.org/) version 2.8+ 
+- [CMake](https://cmake.org/) version 3.5+ 
 - [OpenGL](https://www.opengl.org)
 - [Qt5 Development Libraries](https://www.qt.io)
 - [Open Dynamics Engine (ODE)](http://www.ode.org)

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ grSim compiles on Linux (tested on Ubuntu variants only) and Mac OS. It depends 
 
 - [CMake](https://cmake.org/) version 2.8+ 
 - [OpenGL](https://www.opengl.org)
-- [Qt4 Development Libraries](https://www.qt.io) version 4.8+
+- [Qt5 Development Libraries](https://www.qt.io)
 - [Open Dynamics Engine (ODE)](http://www.ode.org)
-- [VarTypes Library](https://github.com/szi/vartypes)
+- [VarTypes Library](https://github.com/jpfeltracco/vartypes) forked from [Szi's Vartypes](https://github.com/szi/vartypes)
 - [Google Protobuf](https://github.com/google/protobuf)
 - [Boost development libraries](http://www.boost.org/) (needed by VarTypes)
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Software Requirements
 
 grSim compiles on Linux (tested on Ubuntu variants only) and Mac OS. It depends on the following libraries:
 
-- [CMake](https://cmake.org/) version 2.8+ 
+- [CMake](https://cmake.org/) version 3.5+ 
 - [OpenGL](https://www.opengl.org)
 - [Qt5 Development Libraries](https://www.qt.io)
 - [Open Dynamics Engine (ODE)](http://www.ode.org)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 grSim-[![Build Status](https://travis-ci.org/RoboCup-SSL/grSim.svg?branch=master)](https://travis-ci.org/RoboCup-SSL/grSim)[![CodeFactor](https://www.codefactor.io/repository/github/parsianroboticlab/grsim/badge/master)](https://www.codefactor.io/repository/github/parsianroboticlab/grsim/overview/master)
 =======================
 
-[RoboCup Small Size League](http://wiki.robocup.org/Small_Size_League) Simulator.
+[RoboCup Small Size League](https://ssl.robocup.org/) Simulator.
 
 ![grSim on Ubuntu](docs/img/screenshot01.jpg?raw=true "grSim on Ubuntu")
 


### PR DESCRIPTION
### Description of the Change

This pull request updates links in some documents.
It contains the change related to dependency updates (VarTypes and Qt5 - see #90)  
and updates of links for grSim repository in the installation procedure for Linux/Unix.
Link for Parsian's we page also updated because old page (wiki.robocup.org) is no longer exists.

Related with the work #93, requirement for CMake also updated from v2.8 to v3.5. 

Also updates for CHANGELOG.md are contains in this pull request.
Update link for commit history, add the [activities for Milestone 2.0](https://github.com/RoboCup-SSL/grSim/milestone/3).
(CHANGELOG.md already updated on 2016.11 so I've skipped 1.5.)

closes #94 .

### Release Notes

N/A