### PR TITLE
Make ball replacement fields optional

### DIFF
--- a/src/proto/grSim_Commands.proto
+++ b/src/proto/grSim_Commands.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 message grSim_Robot_Command {
 required uint32 id = 1;
 required float kickspeedx = 2;

--- a/src/proto/grSim_Packet.proto
+++ b/src/proto/grSim_Packet.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "grSim_Commands.proto";
 import "grSim_Replacement.proto";
 message grSim_Packet {

--- a/src/proto/grSim_Replacement.proto
+++ b/src/proto/grSim_Replacement.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 message grSim_RobotReplacement {
 required double x=1;
 required double y=2;

--- a/src/proto/grSim_Replacement.proto
+++ b/src/proto/grSim_Replacement.proto
@@ -10,13 +10,13 @@ optional bool turnon=6;
 }
 
 message grSim_BallReplacement {
-required double x=1;
-required double y=2;
-required double vx=3;
-required double vy=4;
+optional double x=1;
+optional double y=2;
+optional double vx=3;
+optional double vy=4;
 }
 
 message grSim_Replacement {
-optional grSim_BallReplacement ball = 1;
-repeated grSim_RobotReplacement robots = 2;
+optional grSim_BallReplacement ball=1;
+repeated grSim_RobotReplacement robots=2;
 }

--- a/src/proto/messages_robocup_ssl_detection.proto
+++ b/src/proto/messages_robocup_ssl_detection.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 message SSL_DetectionBall {
   required float  confidence = 1;
   optional uint32 area       = 2;

--- a/src/proto/messages_robocup_ssl_geometry.proto
+++ b/src/proto/messages_robocup_ssl_geometry.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 // A 2D float vector.
 message Vector2f {
   required float x = 1;

--- a/src/proto/messages_robocup_ssl_refbox_log.proto
+++ b/src/proto/messages_robocup_ssl_refbox_log.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "messages_robocup_ssl_detection.proto";
 
 message Log_Frame

--- a/src/proto/messages_robocup_ssl_wrapper.proto
+++ b/src/proto/messages_robocup_ssl_wrapper.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "messages_robocup_ssl_detection.proto";
 import "messages_robocup_ssl_geometry.proto";
 

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -595,11 +595,17 @@ void SSLWorld::recvActions()
                 }
                 if (packet.replacement().has_ball())
                 {
-                    dReal x = 0, y = 0, vx = 0, vy = 0;
+                    dReal x = 0, y = 0, z = 0, vx = 0, vy = 0;
+                    ball->getBodyPosition(x, y, z);
+                    const auto vel_vec = dBodyGetLinearVel(ball->body);
+                    vx = vel_vec[0];
+                    vy = vel_vec[1];
+
                     if (packet.replacement().ball().has_x())  x  = packet.replacement().ball().x();
                     if (packet.replacement().ball().has_y())  y  = packet.replacement().ball().y();
                     if (packet.replacement().ball().has_vx()) vx = packet.replacement().ball().vx();
                     if (packet.replacement().ball().has_vy()) vy = packet.replacement().ball().vy();
+
                     ball->setBodyPosition(x,y,cfg->BallRadius()*1.2);
                     dBodySetLinearVel(ball->body,vx,vy,0);
                     dBodySetAngularVel(ball->body,0,0,0);


### PR DESCRIPTION
### Note

This should be merged after #96 

### Issue or RFC Endorsed by GrSim's Maintainers

closes #97 

### Description of the Change

Users of grSim can specify a manual ball position and velocity through the `grSim_BallReplacement` proto message. This message requires position and velocity to be set in order to work. This PR makes those fields optional and reuses position or velocity values if they are not set in the proto, allowing users to only modify ball velocity if desired.

### Alternate Designs

Could've added a whole new message, but this is nice and maintains compatibility.

### Possible Drawbacks

None, users of the proto shouldn't be affected.

### Verification Process

Manually modify client to send another packet with a replacement command that moves the ball, for example:

```cpp
grSim_Packet r_pkt;
r_pkt.mutable_replacement()->mutable_ball()->set_vx(-0.5);
r_pkt.mutable_replacement()->mutable_ball()->set_vy(-0.5);
dgram.resize(r_pkt.ByteSize());
r_pkt.SerializeToArray(dgram.data(), dgram.size());
udpsocket.writeDatagram(dgram, _addr, _port);
```

Should maybe split up the receive function into some smaller functions that we could unit test.

### Release Notes