### PR TITLE
load configuration from system install directory on Linux (from NAMeC)

### DIFF
--- a/src/configwidget.cpp
+++ b/src/configwidget.cpp
@@ -134,7 +134,6 @@ ConfigWidget::ConfigWidget()
     world=VarXML::read(world,(QDir::homePath() + QString("/.grsim.xml")).toStdString());
 
 
-    QDir dir;
     std::string blueteam = v_BlueTeam->getString();
     geo_vars->removeChild(v_BlueTeam);
 
@@ -144,22 +143,18 @@ ConfigWidget::ConfigWidget()
     ADD_ENUM(StringEnum,BlueTeam,blueteam.c_str(),"Blue Team");
     ADD_ENUM(StringEnum,YellowTeam,yellowteam.c_str(),"Yellow Team");
 
-    dir.setCurrent(qApp->applicationDirPath()+"/../config/");
+    auto config_path = "/../config/";
+#ifdef HAVE_LINUX
+    bool grSim_launch_from_system_dir = (qApp->applicationDirPath().indexOf(QDir::homePath()) == -1);
+    if (grSim_launch_from_system_dir)
+      config_path = "/../share/grSim/config/";
+#endif
+    QDir dir;
+    dir.setCurrent(qApp->applicationDirPath() + config_path);
     dir.setNameFilters(QStringList() << "*.ini");
     dir.setSorting(QDir::Size | QDir::Reversed);
     QFileInfoList list = dir.entryInfoList();
-    for (int i = 0; i < list.size(); ++i) {
-        QFileInfo fileInfo = list.at(i);
-        QStringList s = fileInfo.fileName().split(".");
-        QString str;
-        if (s.count() > 0) str = s[0];
-        ADD_TO_ENUM(BlueTeam,str.toStdString())
-        ADD_TO_ENUM(YellowTeam,str.toStdString())
-    }
-    dir.setCurrent(qApp->applicationDirPath()+"/../share/grsim/config/");
-    dir.setNameFilters(QStringList() << "*.ini");
-    dir.setSorting(QDir::Size | QDir::Reversed);
-    list = dir.entryInfoList();
+
     for (int i = 0; i < list.size(); ++i) {
         QFileInfo fileInfo = list.at(i);
         QStringList s = fileInfo.fileName().split(".");
@@ -215,7 +210,14 @@ void ConfigWidget::loadRobotsSettings()
 
 void ConfigWidget::loadRobotSettings(QString team)
 {
-    QString ss = qApp->applicationDirPath()+QString("/../config/")+QString("%1.ini").arg(team);
+    auto config_path = "/../config/";
+#ifdef HAVE_LINUX
+    bool grSim_launch_from_system_dir = (qApp->applicationDirPath().indexOf(QDir::homePath()) == -1);
+    if (grSim_launch_from_system_dir)
+      config_path = "/../share/grSim/config/";
+#endif
+
+    QString ss = qApp->applicationDirPath()+QString(config_path)+QString("%1.ini").arg(team);
     robot_settings = new QSettings(ss, QSettings::IniFormat);
     robotSettings.RobotCenterFromKicker = robot_settings->value("Geometery/CenterFromKicker", 0.073).toDouble();
     robotSettings.RobotRadius = robot_settings->value("Geometery/Radius", 0.09).toDouble();
@@ -232,9 +234,9 @@ void ConfigWidget::loadRobotSettings(QString team)
     robotSettings.Wheel3Angle = robot_settings->value("Geometery/Wheel3Angle", 225).toDouble();
     robotSettings.Wheel4Angle = robot_settings->value("Geometery/Wheel4Angle", 300).toDouble();
 
-    robotSettings.BodyMass  = robot_settings->value("Physics/BodyMass", 2).toDouble();
+    robotSettings.BodyMass = robot_settings->value("Physics/BodyMass", 2).toDouble();
     robotSettings.WheelMass = robot_settings->value("Physics/WheelMass", 0.2).toDouble();
-    robotSettings.KickerMass= robot_settings->value("Physics/KickerMass",0.02).toDouble();
+    robotSettings.KickerMass = robot_settings->value("Physics/KickerMass", 0.02).toDouble();
     robotSettings.KickerDampFactor = robot_settings->value("Physics/KickerDampFactor", 0.2f).toDouble();
     robotSettings.RollerTorqueFactor = robot_settings->value("Physics/RollerTorqueFactor", 0.06f).toDouble();
     robotSettings.RollerPerpendicularTorqueFactor = robot_settings->value("Physics/RollerPerpendicularTorqueFactor", 0.005f).toDouble();


### PR DESCRIPTION
### Issue or RFC Endorsed by GrSim's Maintainers

grSim can be installed under system's directories but is only able to load configuration files from it's relative directory:  _../config_.

### Description of the Change

- For Linux user, when grSim is executes under the _/usr/_ directory it will look into the configuration folder that is currently installed on the system: _/usr/local/share/grSim/config/_
- delete old code (useless)
 
### Alternate Designs

As an alternative, we could use an environment variable and read it, if defined. This could be more flexible but introduce external modifications.

### Possible Drawbacks

If an user changes the default install directory then no configuration can be load as before.

### Verification Process

```bash
mkdir build && cd build
cmake ..
sudo make install
touch ../config/TMP.ini
grSim     # TMP.ini is not present in the configuration file list
```
Please close grSim.
```bash
rm ~/.grsim.xml  # to remove old entries automaticaly
cd ../bin/
./grSim   # TMP.ini is present in the configuration file list
```