### PR TITLE
Fixed segmentation fault when settings 'Geometry>Game>Robots Count' to 0

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -329,17 +329,21 @@ void MainWindow::update()
 
     int R = robotIndex(glwidget->Current_robot,glwidget->Current_team);
 
-    const dReal* vv = dBodyGetLinearVel(glwidget->ssl->robots[R]->chassis->body);
-    static dVector3 lvv;
-    dVector3 aa;
-    aa[0]=(vv[0]-lvv[0])/configwidget->DeltaTime();
-    aa[1]=(vv[1]-lvv[1])/configwidget->DeltaTime();
-    aa[2]=(vv[2]-lvv[2])/configwidget->DeltaTime();
-    robotwidget->vellabel->setText(QString::number(sqrt(vv[0]*vv[0]+vv[1]*vv[1]+vv[2]*vv[2]),'f',3));
-    robotwidget->acclabel->setText(QString::number(sqrt(aa[0]*aa[0]+aa[1]*aa[1]+aa[2]*aa[2]),'f',3));
-    lvv[0]=vv[0];
-    lvv[1]=vv[1];
-    lvv[2]=vv[2];
+    if(0 <= R)
+    {
+        const dReal* vv = dBodyGetLinearVel(glwidget->ssl->robots[R]->chassis->body);
+        static dVector3 lvv;
+        dVector3 aa;
+        aa[0]=(vv[0]-lvv[0])/configwidget->DeltaTime();
+        aa[1]=(vv[1]-lvv[1])/configwidget->DeltaTime();
+        aa[2]=(vv[2]-lvv[2])/configwidget->DeltaTime();
+        robotwidget->vellabel->setText(QString::number(sqrt(vv[0]*vv[0]+vv[1]*vv[1]+vv[2]*vv[2]),'f',3));
+        robotwidget->acclabel->setText(QString::number(sqrt(aa[0]*aa[0]+aa[1]*aa[1]+aa[2]*aa[2]),'f',3));
+        lvv[0]=vv[0];
+        lvv[1]=vv[1];
+        lvv[2]=vv[2];
+    }
+    
     QString ss;
     fpslabel->setText(QString("Frame rate: %1 fps").arg(ss.sprintf("%06.2f",glwidget->getFPS())));        
     if (glwidget->ssl->selected!=-1)


### PR DESCRIPTION
### Identify the Bug

When setting Geometry > Game > Robots Count to 0, GrSim segfaults.

### Description of the Change

I threw GrSim in a debugger, and there is a bug in src/mainwindow.cpp. When there are no robots in the field, R is set to -1. This gives a segmentation fault. Putting that part of the code in an if-statement seems to fix it. I have not seen any other side effects of this change.