### PR TITLE
Shrink current robot selector comboBox based on robot count

### DIFF
--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -43,6 +43,8 @@ public slots:
     void changeCurrentRobot();
     void changeCurrentTeam();
 
+    void changeRobotCount();
+
     void changeBallMass();   
     void changeBallGroundSurface();    
     void changeBallDamping();

--- a/include/robotwidget.h
+++ b/include/robotwidget.h
@@ -33,6 +33,8 @@ class RobotWidget : public QDockWidget
 public:    
     RobotWidget(QWidget* parent, ConfigWidget* cfg);
     void setPicture(QImage* img);
+    void changeRobotCount(int newRobotCount);
+    void changeCurrentRobot(int CurrentRobotID);
     QComboBox *teamCombo,*robotCombo;
     QLabel *robotpic;
     QLabel *vellabel,*acclabel;

--- a/src/robotwidget.cpp
+++ b/src/robotwidget.cpp
@@ -36,10 +36,7 @@ RobotWidget::RobotWidget(QWidget* parent, ConfigWidget* cfg)
     robotCombo = new QComboBox(this);
 
     // Add items to the combo box dynamically 
-    for (int i=0; i<cfg->Robots_Count(); i++){
-      QString item=QString::number(i);
-      robotCombo->addItem(item);
-    }
+    changeRobotCount(cfg->Robots_Count());
 
     vellabel = new QLabel;
     acclabel = new QLabel;
@@ -64,6 +61,33 @@ RobotWidget::RobotWidget(QWidget* parent, ConfigWidget* cfg)
     setWidget(widget);
     getPoseWidget = new GetPositionWidget();
     QObject::connect(setPoseBtn,SIGNAL(clicked()),this,SLOT(setPoseBtnClicked()));
+}
+
+void RobotWidget::changeRobotCount(int newRobotCount) {
+    // block signal emitting to avoid segmentation fault
+    // if don't do this, CurrentIndexChange() signal will be emitted everytime adding/deleting item
+    // and MainWindow::changeCurrentRobot() will be called
+    robotCombo->blockSignals(true);
+
+    // increase comboBox element
+    if(newRobotCount > robotCombo->count()) {
+        for (int i=robotCombo->count(); i<newRobotCount; i++){
+            QString item=QString::number(i);
+            robotCombo->addItem(item);
+        }
+    }
+    // decrease comboBox element
+    else {
+        for (int i=robotCombo->count(); i>=newRobotCount; i--) {
+            robotCombo->removeItem(i);
+        }
+    }
+    robotCombo->blockSignals(false);
+}
+
+void RobotWidget::changeCurrentRobot(int CurrentRobotID) {
+    CurrentRobotID = std::min(CurrentRobotID, robotCombo->count()-1);
+    robotCombo->setCurrentIndex(CurrentRobotID);
 }
 
 void RobotWidget::setPicture(QImage* img)


### PR DESCRIPTION
### Identify the Bug

Closes #116
Size of ID selection combo box in "Current Robot" widget is defined when RobotWidget object is created, and not updated even robot count is updated.
So, we can select a robot does not exists on field.  This causes out-of-range access and segmentation fault.
More details are described in #116 

### Description of the Change

Most of changes happen to configuration widget (e.g. number of robots, division, field size and more) are connected to `MainWindow::restartSimulator()`.
Now, I implemented new function `MainWindow::changeRobotCount()`, `RobotWidget::changeRobotCount()` and `RobotWidget::changeCurrentTeam()`.  
Change of robot count will call this.

`MainWindow::changeRobotCount()` follows those step:
1. clamp new robot count to fit to 0 ~ maximum robot count  
  Currently it is 12, but will be increased to 16
1. call `RobotWidget::changeRobotCount()`. 
  It will shrink the size of drop down list for current robot selector
1. check if current robot index is in the allowed range.
1. call `RobotWidget::changeCurrentRobot()`.
1. Finally call `MainWindow::restartSimulator()` to apply those changes

### Alternate Designs

`MainWindow::changeRobotCount()` is independent function, but it could be merged into `MainWindow::restartSimulator()`

### Possible Drawbacks

During `robot count` is 0 : 
- User cannot update `current robot` 
- User can update `current team` but current robot image will not updated (because `current robot` is undefined)

### Verification Process

Set `current robot` and `robot count` randomly, and verify that no segmentation fault occurred.
Tested on Arch Linux, Fedora 31, 32, Ubuntu 18.04, 20.04

### Release Notes

Make "current robot selector" to shrink to fit to number of robots

