### PR TITLE
fix initial positions for increased robots

### DIFF
--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -905,7 +905,7 @@ void SSLWorld::sendVisionBuffer()
 
 void RobotsFomation::setAll(dReal* xx,dReal *yy)
 {
-    for (int i=0;i<cfg->Robots_Count();i++)
+    for (int i=0;i<MAX_ROBOT_COUNT;i++)
     {
         x[i] = xx[i];
         y[i] = yy[i];


### PR DESCRIPTION
### Identify the Bug

Closes #115 
When increase robot count from configuration widget, increased robot are placed to (x, y) = (0, 0) as show in #115.
This is happen because  
1. `RobotFomation::setAll()` only copies new robot position 0 ~ `Robots_Count()`
2. `setAll()` is only called when RobotFomation object is created
3. initial formations are defined in `RobotFomation::RobotFomation()` as temporal variable, so cannot refer from outside

### Description of the Change

Simply change condition used in `RobotFomation::setAll()` : `cfg->RobotCount()` to `MAX_ROBOT_COUNT`
This is a solution for 1.

### Alternate Designs

Solving 2 and 3 is another way, but it is little bit complex and there're many way to implement.  
For example, with minimum changes,
1. create static formation constant in `RobotFomation` class
2. in `MainWindow::restartSimulator()`, initialize `glwidget->forms[i]` using the constant and new `Robot_count` before creating new `SSLWorld`

like this:
```cpp
// formation constant : [number of formation][dimension : x and y so 2][size]
// static const dReal RobotFomation::formation[4][2][MAX_ROBOT_COUNT]

void MainWindow::restartSimulator()
{        
    delete glwidget->ssl;
    // robot count is already updated so setAll() copies positions for existing robots
    glwidget->forms[2]->setAll(RobotFomation::formation[1][0], RobotFomation::formation[1][1])
    // create new SSLWorld using updated forms
    glwidget->ssl = new SSLWorld(glwidget,glwidget->cfg,glwidget->forms[2],glwidget->forms[2]);
    glwidget->ssl->glinit();
    glwidget->ssl->visionServer = visionServer;
    glwidget->ssl->commandSocket = commandSocket;
    glwidget->ssl->blueStatusSocket = blueStatusSocket;
    glwidget->ssl->yellowStatusSocket = yellowStatusSocket;
}
```

### Possible Drawbacks

Nothing, I think

### Verification Process

1. Launch grSim and increase robot count
  Make sure that increased robots are placed where we want, not to center
2. Decrease robot count and close grSim
3. Re-launch grSim and check formation formation
4. Increase robot count and check formation

### Release Notes

Fix undefined robot formation when increasing robots count