### PR TITLE
Fixed segmentation faults

### DIFF
--- a/include/glwidget.h
+++ b/include/glwidget.h
@@ -21,7 +21,6 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 
 #define GL_SILENCE_DEPRECATION
 #include <QGLWidget>
-#include <QGraphicsView>
 #include <QTime>
 #include <QMenu>
 
@@ -29,7 +28,6 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 #include "configwidget.h"
 
 
-class GLWidgetGraphicsView;
 class GLWidget : public QGLWidget {
 
     Q_OBJECT
@@ -58,7 +56,6 @@ public:
     bool ctrl,alt,kickingball,altTrigger;
     bool chiping;
     double kickpower, chipAngle;
-    bool fullScreen;
     void update3DCursor(int mouse_x,int mouse_y);
     void putBall(dReal x,dReal y);
     void reform(int team,const QString& act);    
@@ -83,7 +80,6 @@ signals:
     void clicked();
     void selectedRobot();
     void closeSignal(bool);
-    void toggleFullScreen(bool);
     void robotTurnedOnOff(int,bool);
 protected:
     void paintGL ();
@@ -104,22 +100,6 @@ private:
     QTime time,rendertimer;
     dReal m_fps;
     QPoint lastPos;
-friend class GLWidgetGraphicsView;
-};
-
-class GLWidgetGraphicsView : public QGraphicsView        
-{
-    private:
-        GLWidget *glwidget;
-    public:
-        GLWidgetGraphicsView(QGraphicsScene *scene,GLWidget* _glwidget);
-    protected:
-        void mousePressEvent(QMouseEvent *event);
-        void mouseMoveEvent(QMouseEvent *event);
-        void mouseReleaseEvent(QMouseEvent *event);
-        void wheelEvent(QWheelEvent *event);
-        void keyPressEvent(QKeyEvent *event);
-        void closeEvent(QCloseEvent *event);
 };
 
 #endif // WIDGET_H

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -71,7 +71,6 @@ public slots:
 private:
     int getInterval();    
     QTimer *timer;
-    QMdiArea* workspace;
     GLWidget *glwidget;
     ConfigWidget *configwidget;
     ConfigDockWidget *dockconfig;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -75,18 +75,16 @@ private:
     ConfigWidget *configwidget;
     ConfigDockWidget *dockconfig;
     RobotWidget *robotwidget;        
+    QByteArray prevState;
 
     CStatusPrinter *printer;
     CStatusWidget *statusWidget;
 
-    QAction *showsimulator, *showconfig;
+    QAction *showsimulator, *showconfig, *showrobot;
     QAction* fullScreenAct;
     QLabel *fpslabel,*cursorlabel,*selectinglabel,*vanishlabel,*noiselabel;
     QString current_dir;
 
-    QGraphicsScene *scene;
-    GLWidgetGraphicsView *view;
-    QSize lastSize;
     RoboCupSSLServer *visionServer;
     QUdpSocket *commandSocket;
     QUdpSocket *blueStatusSocket,*yellowStatusSocket;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -38,7 +38,6 @@ public:
 public slots:
     void update();
     void updateRobotLabel();
-    void showHideConfig(bool v);
     void showHideSimulator(bool v);
     void changeCurrentRobot();
     void changeCurrentTeam();

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -110,7 +110,6 @@ GLWidget::GLWidget(QWidget *parent, ConfigWidget* _cfg)
     connect(lockToBallAct, SIGNAL(triggered()), this, SLOT(lockCameraToBall()));
     connect(changeCamModeAct,SIGNAL(triggered()),this,SLOT(changeCameraMode()));
     setFocusPolicy(Qt::StrongFocus);
-    fullScreen = false;
     ctrl = false;
     alt = false;
     kickingball = false;
@@ -457,9 +456,6 @@ void GLWidget::keyPressEvent(QKeyEvent *event)
     if (event->key() == Qt::Key_Control) ctrl = true;
     if (event->key() == Qt::Key_Alt) alt = true;
     char cmd = static_cast<char>(event->key());
-    if (fullScreen) {
-        if (event->key()==Qt::Key_F2) emit toggleFullScreen(false);
-    }
     const dReal S = 1.00;
     const dReal BallForce = 2.0;
     int R = ssl->robotIndex(Current_robot,Current_team);
@@ -587,17 +583,3 @@ void GLWidget::moveRobotHere()
     ssl->robots[ssl->robotIndex(Current_robot,Current_team)]->setXY(ssl->cursor_x,ssl->cursor_y);
     ssl->robots[ssl->robotIndex(Current_robot,Current_team)]->resetRobot();
 }
-
-GLWidgetGraphicsView::GLWidgetGraphicsView(QGraphicsScene *scene,GLWidget *_glwidget)
-    : QGraphicsView(scene)
-{
-    glwidget = _glwidget;
-}
-
-void GLWidgetGraphicsView::mousePressEvent(QMouseEvent *event) {glwidget->mousePressEvent(event);}
-void GLWidgetGraphicsView::mouseMoveEvent(QMouseEvent *event) {glwidget->mouseMoveEvent(event);}
-void GLWidgetGraphicsView::mouseReleaseEvent(QMouseEvent *event) {glwidget->mouseReleaseEvent(event);}
-void GLWidgetGraphicsView::wheelEvent(QWheelEvent *event) {glwidget->wheelEvent(event);}
-void GLWidgetGraphicsView::keyPressEvent(QKeyEvent *event){glwidget->keyPressEvent(event);}
-void GLWidgetGraphicsView::closeEvent(QCloseEvent *event){} //{viewportEvent(event);}
-

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -67,6 +67,7 @@ MainWindow::MainWindow(QWidget *parent)
     configwidget = new ConfigWidget();
     dockconfig = new ConfigDockWidget(this,configwidget);
     dockconfig->setObjectName("ConfigDockWidget");
+    dockconfig->setWindowTitle("Configuration");
 
     glwidget = new GLWidget(this,configwidget);
     glwidget->setWindowTitle(tr("Simulator"));
@@ -126,9 +127,7 @@ MainWindow::MainWindow(QWidget *parent)
     showsimulator->setCheckable(true);
     showsimulator->setChecked(true);
     viewMenu->addAction(showsimulator);
-    showconfig = new QAction("&Configuration", viewMenu);
-    showconfig->setCheckable(true);
-    showconfig->setChecked(true);
+    showconfig = dockconfig->toggleViewAction();
     viewMenu->addAction(showconfig);
 
     QMenu *simulatorMenu = new QMenu("&Simulator");
@@ -179,9 +178,7 @@ MainWindow::MainWindow(QWidget *parent)
     QObject::connect(takeSnapshotToClipboardAct, SIGNAL(triggered(bool)), this, SLOT(takeSnapshotToClipboard()));
     QObject::connect(exit, SIGNAL(triggered(bool)), this, SLOT(close()));
     QObject::connect(showsimulator, SIGNAL(triggered(bool)), this, SLOT(showHideSimulator(bool)));
-    QObject::connect(showconfig, SIGNAL(triggered(bool)), this, SLOT(showHideConfig(bool)));
     QObject::connect(glwidget, SIGNAL(closeSignal(bool)), this, SLOT(showHideSimulator(bool)));    
-    QObject::connect(dockconfig, SIGNAL(closeSignal(bool)), this, SLOT(showHideConfig(bool)));
     QObject::connect(glwidget, SIGNAL(selectedRobot()), this, SLOT(updateRobotLabel()));
     QObject::connect(robotwidget->robotCombo,SIGNAL(currentIndexChanged(int)),this,SLOT(changeCurrentRobot()));
     QObject::connect(robotwidget->teamCombo,SIGNAL(currentIndexChanged(int)),this,SLOT(changeCurrentTeam()));
@@ -266,12 +263,6 @@ MainWindow::MainWindow(QWidget *parent)
 
 MainWindow::~MainWindow()
 {
-}
-
-void MainWindow::showHideConfig(bool v)
-{
-    if (v) {dockconfig->show();showconfig->setChecked(true);}
-    else {dockconfig->hide();showconfig->setChecked(false);}
 }
 
 void MainWindow::showHideSimulator(bool v)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -61,10 +61,6 @@ MainWindow::MainWindow(QWidget *parent)
     statusWidget = new CStatusWidget(printer);
     initLogger((void*)printer);
 
-    /* Init Workspace */
-    workspace = new QMdiArea(this);
-    setCentralWidget(workspace);    
-
     /* Widgets */
 
     configwidget = new ConfigWidget();
@@ -168,9 +164,7 @@ MainWindow::MainWindow(QWidget *parent)
     addDockWidget(Qt::BottomDockWidgetArea, statusWidget);
     addDockWidget(Qt::LeftDockWidgetArea, robotwidget);
 
-    workspace->addSubWindow(glwidget, Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowMinimizeButtonHint | Qt::WindowMaximizeButtonHint);
-
-    glwidget->setWindowState(Qt::WindowMaximized);
+    setCentralWidget(glwidget);
 
     timer = new QTimer(this);
     timer->setInterval(getInterval());
@@ -472,7 +466,7 @@ void MainWindow::toggleFullScreen(bool a)
     }
     else {
         view->close(); 
-        workspace->addSubWindow(glwidget, Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowMinimizeButtonHint | Qt::WindowMaximizeButtonHint);
+        // workspace->addSubWindow(glwidget, Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowMinimizeButtonHint | Qt::WindowMaximizeButtonHint);
         glwidget->show();
         glwidget->resize(lastSize);
         glwidget->fullScreen = false;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -59,12 +59,14 @@ MainWindow::MainWindow(QWidget *parent)
     /* Status Logger */
     printer = new CStatusPrinter();
     statusWidget = new CStatusWidget(printer);
+    statusWidget->setObjectName("CStatusWidget");
     initLogger((void*)printer);
 
     /* Widgets */
 
     configwidget = new ConfigWidget();
     dockconfig = new ConfigDockWidget(this,configwidget);
+    dockconfig->setObjectName("ConfigDockWidget");
 
     glwidget = new GLWidget(this,configwidget);
     glwidget->setWindowTitle(tr("Simulator"));
@@ -87,6 +89,7 @@ MainWindow::MainWindow(QWidget *parent)
 
 
     robotwidget = new RobotWidget(this, configwidget);
+    robotwidget->setObjectName("RobotWidget");
     /* Status Bar */
     fpslabel = new QLabel(this);
     cursorlabel = new QLabel(this);
@@ -157,7 +160,8 @@ MainWindow::MainWindow(QWidget *parent)
     fullScreenAct->setChecked(false);
     simulatorMenu->addAction(fullScreenAct);
 
-    viewMenu->addAction(robotwidget->toggleViewAction());
+    showrobot = robotwidget->toggleViewAction();
+    viewMenu->addAction(showrobot);
     viewMenu->addMenu(glwidget->cameraMenu);
 
     addDockWidget(Qt::LeftDockWidgetArea,dockconfig);
@@ -258,7 +262,6 @@ MainWindow::MainWindow(QWidget *parent)
     robotwidget->robotCombo->setCurrentIndex(0);
     robotwidget->setPicture(glwidget->ssl->robots[robotIndex(glwidget->Current_robot,glwidget->Current_team)]->img);
     robotwidget->id = 0;
-    scene = new QGraphicsScene(0,0,800,600);    
 }
 
 MainWindow::~MainWindow()
@@ -452,27 +455,20 @@ void MainWindow::toggleFullScreen(bool a)
 {
     if (a)
     {
-        view = new GLWidgetGraphicsView(scene,glwidget);
-        lastSize = glwidget->size();        
-        view->setViewport(glwidget);
-        view->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-        view->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-        view->setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
-        view->setFrameStyle(0);
-        view->showFullScreen();
-        view->setFocus();        
-        glwidget->fullScreen = true;
-        fullScreenAct->setChecked(true);
+        prevState = saveState();
+        for (auto dockwidget : findChildren<QDockWidget*>())
+        {
+            dockwidget->hide();
+        }
+        showconfig->setEnabled(false);
+        showrobot->setEnabled(false);
+        showFullScreen();
     }
     else {
-        view->close(); 
-        // workspace->addSubWindow(glwidget, Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowMinimizeButtonHint | Qt::WindowMaximizeButtonHint);
-        glwidget->show();
-        glwidget->resize(lastSize);
-        glwidget->fullScreen = false;
-        fullScreenAct->setChecked(false);
-        glwidget->setFocusPolicy(Qt::StrongFocus);
-        glwidget->setFocus();
+        showNormal();
+        restoreState(prevState);
+        showconfig->setEnabled(true);
+        showrobot->setEnabled(true);
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -189,7 +189,6 @@ MainWindow::MainWindow(QWidget *parent)
     QObject::connect(glwidget,SIGNAL(robotTurnedOnOff(int,bool)),robotwidget,SLOT(changeRobotOnOff(int,bool)));
     QObject::connect(ballMenu,SIGNAL(triggered(QAction*)),this,SLOT(ballMenuTriggered(QAction*)));
     QObject::connect(fullScreenAct,SIGNAL(triggered(bool)),this,SLOT(toggleFullScreen(bool)));
-    QObject::connect(glwidget,SIGNAL(toggleFullScreen(bool)),this,SLOT(toggleFullScreen(bool)));
     QObject::connect(glwidget->ssl, SIGNAL(fpsChanged(int)), this, SLOT(customFPS(int)));
     QObject::connect(aboutMenu, SIGNAL(triggered()), this, SLOT(showAbout()));
     //config related signals


### PR DESCRIPTION
### Identify the Bug

grSim crashed (segmentation fault) when;
- clicking buttons at the upper right of the simulator view.
    ![Screenshot_2020-06-02-140633](https://user-images.githubusercontent.com/6215720/84569466-c5614100-adc1-11ea-8356-a3074b9b4e7f.png)
- typing the F2 key (or the 'Full screen' checkbox in the 'Simulator' menu) to enter the full-screen mode and then typing the F2 key again to return from the full-screen mode.

### Description of the Change

I think that closing or minimizing the simulator view is not useful to us. Also, it is not needed to use the `QMdiArea` to show a single widget. This PR removes `QMdiArea` from the main window and sets `glwidget` directly to the central widget.

Detaching the widget and passing it to another widget is slightly hard to implement due to the limitation of [Qt's object management system](https://doc.qt.io/qt-5/objecttrees.html). This PR introduces a simpler implementation. After this change, grSim;
1. saves the current layout of dock widgets,
2. hides all dock widgets,
3. and makes the main window full-screen

at entering the full-screen mode; and
1. makes the main window normal size
2. and restores the previous layout of dock widgets

at returning from the full-screen mode.

### Verification Process

Toggle the full-screen mode and check the grSim not to crash.