### PR TITLE
Add enums for statements (camera mode, camera motion mode, 3D cursor mode)

### DIFF
--- a/include/glwidget.h
+++ b/include/glwidget.h
@@ -32,6 +32,23 @@ class GLWidget : public QGLWidget {
 
     Q_OBJECT
 public:
+    enum class CursorMode {
+        STEADY = 0,
+        PLACE_ROBOT = 1,
+        PLACE_BALL = 2,
+    };
+    enum class CameraMode {
+        BIRDS_EYE_FROM_TOUCH_LINE = 0,
+        CURRENT_ROBOT_VIEW = 1,
+        TOP_VIEW = 2,
+        BIRDS_EYE_FROM_OPPOSITE_TOUCH_LINE = 3,
+        BIRDS_EYE_FROM_BLUE = 4,
+        BIRDS_EYE_FROM_YELLOW = 5,
+        MAX_ACTIVE_MODE_FOR_CHANGEMODE=BIRDS_EYE_FROM_YELLOW,
+        // non-avaliable modes when "toggle camera mode" called
+        LOCK_TO_ROBOT = -1,
+        LOCK_TO_BALL = -2,
+    };
     GLWidget(QWidget *parent,ConfigWidget* _cfg);
     ~GLWidget();
     dReal getFPS();
@@ -51,7 +68,7 @@ public:
     QAction* moveRobotHereAct;
     QAction* changeCamModeAct;
     QMenu *cameraMenu;
-    int Current_robot,Current_team,cammode;
+    int Current_robot,Current_team;
     int lockedIndex;
     bool ctrl,alt,kickingball,altTrigger;
     bool chiping;
@@ -93,7 +110,8 @@ protected:
     void keyReleaseEvent(QKeyEvent* event);
     void closeEvent(QCloseEvent *event);    
 private:
-    int state;
+    CursorMode state;
+    CameraMode cammode;
     int moving_robot_id,clicked_robot;
     int frames;
     bool first_time;

--- a/include/graphics.h
+++ b/include/graphics.h
@@ -26,6 +26,11 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 #include <QGLWidget>
 #include <QString>
 
+enum CameraMotionMode {
+    ROTATE_VIEW_POINT = 1,
+    MOVE_POSITION_FREELY = 2,
+    MOVE_POSITION_LR = 4,
+};
 
 class CGraphics
 {
@@ -61,7 +66,7 @@ public:
     dReal renderDepth();
     void setRenderDepth(dReal depth);
     void setViewpoint (dReal x,dReal y,dReal z,dReal h,dReal p,dReal r);
-    void cameraMotion (int mode, int deltax, int deltay);
+    void cameraMotion (CameraMotionMode mode, int deltax, int deltay);
     void lookAt(dReal x,dReal y,dReal z);
     void getCameraForward(dReal& x,dReal& y,dReal& z);
     void getCameraRight(dReal& x,dReal& y,dReal& z);

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -315,13 +315,13 @@ void GLWidget::mouseMoveEvent(QMouseEvent *event)
     int dy = -(event->y() - lastPos.y());    
     if (event->buttons() & Qt::LeftButton) {
         if (ctrl)
-            ssl->g->cameraMotion(4,dx,dy);
+            ssl->g->cameraMotion(CameraMotionMode::MOVE_POSITION_FREELY,dx,dy);
         else
-            ssl->g->cameraMotion(1,dx,dy);
+            ssl->g->cameraMotion(CameraMotionMode::ROTATE_VIEW_POINT,dx,dy);
     }
     else if (event->buttons() & Qt::MidButton)
     {
-        ssl->g->cameraMotion(2,dx,dy);
+        ssl->g->cameraMotion(CameraMotionMode::MOVE_POSITION_LR,dx,dy);
     }
     lastPos = event->pos();
     update3DCursor(event->x(),event->y());

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -31,7 +31,7 @@ GLWidget::GLWidget(QWidget *parent, ConfigWidget* _cfg)
     : QGLWidget(parent)
 {
     frames = 0;
-    state = 0;
+    state = CursorMode::STEADY;
     first_time = true;
     cfg = _cfg;
 
@@ -44,7 +44,7 @@ GLWidget::GLWidget(QWidget *parent, ConfigWidget* _cfg)
     ssl = new SSLWorld(this,cfg,forms[2],forms[2]);
     Current_robot = 0;
     Current_team = 0;
-    cammode = 0;
+    cammode = CameraMode::BIRDS_EYE_FROM_TOUCH_LINE;
     setMouseTracking(true);
 
     blueRobotsMenu = new QMenu("&Blue Robots");
@@ -127,7 +127,7 @@ void GLWidget::moveRobot()
 {
     ssl->show3DCursor = true;
     ssl->cursor_radius = cfg->robotSettings.RobotRadius;
-    state = 1;
+    state = CursorMode::PLACE_ROBOT;
     moving_robot_id = clicked_robot;
 }
 
@@ -135,7 +135,7 @@ void GLWidget::unselectRobot()
 {
     ssl->show3DCursor = false;
     ssl->cursor_radius = cfg->robotSettings.RobotRadius;
-    state = 0;
+    state = CursorMode::STEADY;
     moving_robot_id= ssl->robotIndex(Current_robot,Current_team);
 }
 
@@ -185,7 +185,7 @@ void GLWidget::moveCurrentRobot()
 {
     ssl->show3DCursor = true;
     ssl->cursor_radius = cfg->robotSettings.RobotRadius;
-    state = 1;
+    state = CursorMode::PLACE_ROBOT;
     moving_robot_id = ssl->robotIndex(Current_robot,Current_team);
 }
 
@@ -193,7 +193,7 @@ void GLWidget::moveBall()
 {
     ssl->show3DCursor = true;
     ssl->cursor_radius = cfg->BallRadius();
-    state = 2;
+    state = CursorMode::PLACE_BALL;
 }
 
 void GLWidget::mousePressEvent(QMouseEvent *event)
@@ -202,22 +202,22 @@ void GLWidget::mousePressEvent(QMouseEvent *event)
     lastPos = event->pos();
     if (event->buttons() & Qt::LeftButton)
     {
-        if (state==1)
+        if (state==CursorMode::PLACE_ROBOT)
         {
             if (moving_robot_id!=-1)
             {
                 ssl->robots[moving_robot_id]->setXY(ssl->cursor_x,ssl->cursor_y);
-                state = 0;
+                state = CursorMode::STEADY;
                 ssl->show3DCursor = false;
             }
         }
-        else if (state==2)
+        else if (state==CursorMode::PLACE_BALL)
         {
             ssl->ball->setBodyPosition(ssl->cursor_x,ssl->cursor_y,cfg->BallRadius()*1.1*20.0);
             dBodySetAngularVel(ssl->ball->body,0,0,0);
             dBodySetLinearVel(ssl->ball->body,0,0,0);
             ssl->show3DCursor = false;
-            state = 0;
+            state = CursorMode::STEADY;
         }
         else {
             if (ssl->selected>=0){
@@ -372,20 +372,20 @@ void GLWidget::step()
 void GLWidget::paintGL()
 {
     if (!ssl->g->isGraphicsEnabled()) return;
-    if (cammode==1)
+    if (cammode==CameraMode::CURRENT_ROBOT_VIEW)
     {
         dReal x,y,z;
         int R = ssl->robotIndex(Current_robot,Current_team);
         ssl->robots[R]->getXY(x,y);z = 0.3;
         ssl->g->setViewpoint(x,y,z,ssl->robots[R]->getDir(),-25,0);
     }
-    if (cammode==-1)
+    if (cammode==CameraMode::LOCK_TO_ROBOT)
     {
         dReal x,y,z;
         ssl->robots[lockedIndex]->getXY(x,y);z = 0.1;
         ssl->g->lookAt(x,y,z);
     }
-    if (cammode==-2)
+    else if(cammode==CameraMode::LOCK_TO_BALL)
     {
         dReal x,y,z;
         ssl->ball->getBodyPosition(x,y,z);
@@ -412,22 +412,21 @@ void GLWidget::paintGL()
 void GLWidget::changeCameraMode()
 {
     static dReal xyz[3],hpr[3];
-    if (cammode<0) cammode=0;
-    else cammode ++;
-    cammode %= 6;
-    if (cammode==0)
+    if(static_cast<int>(cammode)<0) cammode=CameraMode::BIRDS_EYE_FROM_TOUCH_LINE;
+    cammode = static_cast<CameraMode>(static_cast<int>(cammode) + 1);
+    cammode = static_cast<CameraMode>(static_cast<int>(cammode)%(static_cast<int>(CameraMode::MAX_ACTIVE_MODE_FOR_CHANGEMODE)+1));
+
+    if (cammode==CameraMode::BIRDS_EYE_FROM_TOUCH_LINE)
         ssl->g->setViewpoint(0,-(cfg->Field_Width()+cfg->Field_Margin()*2.0f)/2.0f,3,90,-45,0);
-    else if (cammode==1)
-    {
+    else if (cammode==CameraMode::CURRENT_ROBOT_VIEW)
         ssl->g->getViewpoint(xyz,hpr);
-    }
-    else if (cammode==2)
+    else if (cammode==CameraMode::TOP_VIEW)
         ssl->g->setViewpoint(0,0,5,0,-90,0);
-    else if (cammode==3)
+    else if (cammode==CameraMode::BIRDS_EYE_FROM_OPPOSITE_TOUCH_LINE)
         ssl->g->setViewpoint(0, (cfg->Field_Width()+cfg->Field_Margin()*2.0f)/2.0f,3,270,-45,0);
-    else if (cammode==4)
+    else if (cammode==CameraMode::BIRDS_EYE_FROM_BLUE)
         ssl->g->setViewpoint(-(cfg->Field_Length()+cfg->Field_Margin()*2.0f)/2.0f,0,3,0,-45,0);
-    else if (cammode==5)
+    else if (cammode==CameraMode::BIRDS_EYE_FROM_YELLOW)
         ssl->g->setViewpoint((cfg->Field_Length()+cfg->Field_Margin()*2.0f)/2.0f,0,3,180,-45,0);
 }
 
@@ -569,13 +568,13 @@ void GLWidget::moveBallHere()
 
 void GLWidget::lockCameraToRobot()
 {
-    cammode = -1;
+    cammode = CameraMode::LOCK_TO_ROBOT;
     lockedIndex = ssl->robotIndex(Current_robot,Current_team);//clicked_robot;
 }
 
 void GLWidget::lockCameraToBall()
 {
-    cammode = -2;
+    cammode = CameraMode::LOCK_TO_BALL;
 }
 
 void GLWidget::moveRobotHere()

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -181,22 +181,22 @@ void CGraphics::wrapCameraAngles()
     }
 }
 
-void CGraphics::cameraMotion (int mode, int deltax, int deltay)
+void CGraphics::cameraMotion (CameraMotionMode mode, int deltax, int deltay)
 {
     if (graphicDisabled) return;
     dReal side = 0.01f * dReal(deltax);
-    dReal fwd = (mode==4) ? (0.01f * dReal(deltay)) : 0.0f;
+    dReal fwd = (mode==CameraMotionMode::ROTATE_VIEW_POINT) ? (0.01f * dReal(deltay)) : 0.0f;
     dReal s = (dReal) sin (view_hpr[0]*M_PI/180.0f);
     dReal c = (dReal) cos (view_hpr[0]*M_PI/180.0f);
 
-    if (mode==1) {
+    if (mode==CameraMotionMode::ROTATE_VIEW_POINT) {
         view_hpr[0] += dReal (deltax) * 0.5f;
         view_hpr[1] += dReal (deltay) * 0.5f;
     }
     else {
         view_xyz[0] += -s*side + c*fwd;
         view_xyz[1] += c*side + s*fwd;
-        if (mode==2 || mode==5) view_xyz[2] += 0.01f * dReal(deltay);
+        if (mode==CameraMotionMode::MOVE_POSITION_FREELY) view_xyz[2] += 0.01f * dReal(deltay);
     }
     wrapCameraAngles();
 }


### PR DESCRIPTION
### Issue or RFC Endorsed by GrSim's Maintainers

little bit related to #27 .

### Description of the Change

Those statements flags are treated as `int`.
adding enum to describe how those statements works makes easier to read code, and also we can write documentation easier.

### Alternate Designs

### Possible Drawbacks

### Verification Process

### Release Notes

N/A