### PR TITLE
Remove delay for cams 1-3 when publishing packets

### DIFF
--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -930,10 +930,10 @@ SendingPacket::SendingPacket(SSL_WrapperPacket* _packet,int _t)
 void SSLWorld::sendVisionBuffer()
 {
     int t = timer->elapsed();
-    sendQueue.push_back(new SendingPacket(generatePacket(0),t));    
-    sendQueue.push_back(new SendingPacket(generatePacket(1),t+1));
-    sendQueue.push_back(new SendingPacket(generatePacket(2),t+2));
-    sendQueue.push_back(new SendingPacket(generatePacket(3),t+3));
+    sendQueue.push_back(new SendingPacket(generatePacket(0),t));
+    sendQueue.push_back(new SendingPacket(generatePacket(1),t));
+    sendQueue.push_back(new SendingPacket(generatePacket(2),t));
+    sendQueue.push_back(new SendingPacket(generatePacket(3),t));
     while (t - sendQueue.front()->t>=cfg->sendDelay())
     {
         SSL_WrapperPacket *packet = sendQueue.front()->packet;


### PR DESCRIPTION
### Issue or RFC Endorsed by GrSim's Maintainers

closes #70

### Description of the Change

The simulator publishes one frame per camera after each simulation step (~60fps).
Right now, a delay is added for each camera. cam0 -> 0ms, cam1 -> 1ms, cam2 -> 2ms, cam3 -> 3ms.
With the current implementation, the package for cam0 is send immediately, the other three are send with the next simulation step, so with 60fps about 16ms later.
This implementation seems unreasonable to me and I thus consider it a bug.

### Alternate Designs

-

### Possible Drawbacks

-

### Verification Process

See #70 for a possible verification.

### Release Notes

Remove delay for cams 1-3 when publishing packets