### PR TITLE
Set fps and simulation step size to reasonable values

### DIFF
--- a/src/configwidget.cpp
+++ b/src/configwidget.cpp
@@ -96,10 +96,10 @@ ConfigWidget::ConfigWidget()
   world.push_back(phys_vars);
     VarListPtr worldp_vars(new VarList("World"));
     phys_vars->addChild(worldp_vars);  
-        ADD_VALUE(worldp_vars,Double,DesiredFPS,65,"Desired FPS")
+        ADD_VALUE(worldp_vars,Double,DesiredFPS,60,"Desired FPS")
         ADD_VALUE(worldp_vars,Bool,SyncWithGL,false,"Synchronize ODE with OpenGL")
-        ADD_VALUE(worldp_vars,Double,DeltaTime,0.016,"ODE time step")
-        ADD_VALUE(worldp_vars,Double,Gravity,9.8,"Gravity")
+        ADD_VALUE(worldp_vars,Double,DeltaTime,1.0/60,"ODE time step")
+        ADD_VALUE(worldp_vars,Double,Gravity,9.81,"Gravity")
         ADD_VALUE(worldp_vars,Bool,ResetTurnOver,true,"Auto reset turn-over")
   VarListPtr ballp_vars(new VarList("Ball"));
     phys_vars->addChild(ballp_vars);


### PR DESCRIPTION
### Identify the Bug

closes #134

### Description of the Change

Updates the default values as described in #134.

### Alternate Designs

-

### Possible Drawbacks

-

### Verification Process

Measure the velocity of objects using position and time difference.

### Release Notes

Set fps and simulation step size to reasonable values