### PR TITLE
sslworld: project airbone balls

### DIFF
--- a/include/configwidget.h
+++ b/include/configwidget.h
@@ -156,6 +156,9 @@ public:
   DEF_FIELD_VALUE(double,Double,Goal_Depth)
   DEF_FIELD_VALUE(double,Double,Goal_Width)
   DEF_FIELD_VALUE(double,Double,Goal_Height)
+  DEF_VALUE(double,Double,Camera_Height)
+  DEF_VALUE(int,Int,Camera_Focal_Length)
+  DEF_VALUE(double,Double,Camera_Scaling_Limit)
 
   DEF_ENUM(std::string,YellowTeam)
   DEF_ENUM(std::string,BlueTeam)

--- a/include/configwidget.h
+++ b/include/configwidget.h
@@ -167,6 +167,7 @@ public:
   DEF_VALUE(double,Double,BallBounceVel)
   DEF_VALUE(double,Double,BallLinearDamp)
   DEF_VALUE(double,Double,BallAngularDamp)
+  DEF_VALUE(bool,Bool,BallProjectAirborne)
 
   DEF_VALUE(bool,Bool,SyncWithGL)
   DEF_VALUE(double,Double,DesiredFPS)

--- a/src/configwidget.cpp
+++ b/src/configwidget.cpp
@@ -110,6 +110,7 @@ ConfigWidget::ConfigWidget()
         ADD_VALUE(ballp_vars,Double,BallBounceVel,0.1,"Ball-ground bounce min velocity")
         ADD_VALUE(ballp_vars,Double,BallLinearDamp,0.004,"Ball linear damping")
         ADD_VALUE(ballp_vars,Double,BallAngularDamp,0.004,"Ball angular damping")
+        ADD_VALUE(ballp_vars,Bool,BallProjectAirborne,true,"Project airborne balls")
   VarListPtr comm_vars(new VarList("Communication"));
   world.push_back(comm_vars);
     ADD_VALUE(comm_vars,String,VisionMulticastAddr,"224.5.23.2","Vision multicast address")  //SSL Vision: "224.5.23.2"

--- a/src/configwidget.cpp
+++ b/src/configwidget.cpp
@@ -88,6 +88,12 @@ ConfigWidget::ConfigWidget()
   END_ENUM(geo_vars,YellowTeam)
   ADD_ENUM(StringEnum,BlueTeam,"Parsian","Blue Team");
   END_ENUM(geo_vars,BlueTeam)
+  VarListPtr camera_vars(new VarList("Cameras"));
+  geo_vars->addChild(camera_vars);
+  ADD_VALUE(camera_vars,Double,Camera_Height,4,"Height of all cameras")
+  ADD_VALUE(camera_vars,Int,Camera_Focal_Length,390,"Focal length")
+  ADD_VALUE(camera_vars,Double,Camera_Scaling_Limit,0.9,"Camera scaling limit")
+
 
     VarListPtr ballg_vars(new VarList("Ball"));
     geo_vars->addChild(ballg_vars);

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -714,6 +714,7 @@ QPair<float, float> SSLWorld::cameraPosition(int id)
             camera_quadrants[id].second * cfg->Field_Width()};
 }
 
+static const bool PROJECT_AIRBONE_BALL = true;
 #define CONVUNIT(x) ((int)(1000*(x)))
 SSL_WrapperPacket* SSLWorld::generatePacket(int cam_id)
 {
@@ -728,6 +729,8 @@ SSL_WrapperPacket* SSLWorld::generatePacket(int cam_id)
     dReal dev_x = cfg->noiseDeviation_x();
     dReal dev_y = cfg->noiseDeviation_y();
     dReal dev_a = cfg->noiseDeviation_angle();
+
+    const float CAMERA_HEIGHT = 4;
 
     // send the geometry for every camera consecutively to provide the camera setup for all of them
     if (((sendGeomCount++) / 4) % (cfg->sendGeometryEvery() / 4) == 0)
@@ -760,7 +763,6 @@ SSL_WrapperPacket* SSLWorld::generatePacket(int cam_id)
         addFieldLinesArcs(field);
 
         // camera calibration
-        const float CAMERA_HEIGHT = 4;
         const unsigned FOCAL_LENGTH = 390;
 
         SSL_GeometryCameraCalibration* camera = geom->add_calib();
@@ -788,10 +790,29 @@ SSL_WrapperPacket* SSLWorld::generatePacket(int cam_id)
     if ((cfg->vanishing()==false) || (rand0_1() > cfg->ball_vanishing()))
     {
         if (visibleInCam(cam_id, x, y)) {
+            const float BALL_RADIUS = 21.5; // mm
+            const float SCALING_LIMIT = 0.9;
             SSL_DetectionBall* vball = packet->mutable_detection()->add_balls();
-            vball->set_x(randn_notrig(x*1000.0f,dev_x));
-            vball->set_y(randn_notrig(y*1000.0f,dev_y));
-            vball->set_z(z*1000.0f);
+
+            float output_x = randn_notrig(x*1000.0f,dev_x);
+            float output_y = randn_notrig(y*1000.0f,dev_x);
+            float output_z = z*1000.0f;
+
+            if (PROJECT_AIRBONE_BALL) {
+                output_z = qBound(0.f, output_z - BALL_RADIUS, CONVUNIT(CAMERA_HEIGHT) * SCALING_LIMIT);
+                auto camera_pos = cameraPosition(cam_id);
+                const float camera_x = CONVUNIT(camera_pos.first);
+                const float camera_y = CONVUNIT(camera_pos.second);
+                const float camera_z = CONVUNIT(CAMERA_HEIGHT);
+                output_x = (output_x - camera_x) * (camera_z / (camera_z - output_z)) + camera_x;
+                output_y = (output_y - camera_y) * (camera_z / (camera_z - output_z)) + camera_y;
+            }
+
+            vball->set_x(output_x);
+            vball->set_y(output_y);
+            if (!PROJECT_AIRBONE_BALL) {
+                vball->set_z(output_z);
+            }
             vball->set_pixel_x(x*1000.0f);
             vball->set_pixel_y(y*1000.0f);
             vball->set_confidence(0.9 + rand0_1()*0.1);

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -714,7 +714,6 @@ QPair<float, float> SSLWorld::cameraPosition(int id)
             camera_quadrants[id].second * cfg->Field_Width()};
 }
 
-static const bool PROJECT_AIRBONE_BALL = true;
 #define CONVUNIT(x) ((int)(1000*(x)))
 SSL_WrapperPacket* SSLWorld::generatePacket(int cam_id)
 {
@@ -798,7 +797,8 @@ SSL_WrapperPacket* SSLWorld::generatePacket(int cam_id)
             float output_y = randn_notrig(y*1000.0f,dev_x);
             float output_z = z*1000.0f;
 
-            if (PROJECT_AIRBONE_BALL) {
+            const bool project_airborne = cfg->BallProjectAirborne();
+            if (project_airborne) {
                 output_z = qBound(0.f, output_z - BALL_RADIUS, CONVUNIT(CAMERA_HEIGHT) * SCALING_LIMIT);
                 auto camera_pos = cameraPosition(cam_id);
                 const float camera_x = CONVUNIT(camera_pos.first);
@@ -810,7 +810,7 @@ SSL_WrapperPacket* SSLWorld::generatePacket(int cam_id)
 
             vball->set_x(output_x);
             vball->set_y(output_y);
-            if (!PROJECT_AIRBONE_BALL) {
+            if (!project_airborne) {
                 vball->set_z(output_z);
             }
             vball->set_pixel_x(x*1000.0f);

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -729,7 +729,7 @@ SSL_WrapperPacket* SSLWorld::generatePacket(int cam_id)
     dReal dev_y = cfg->noiseDeviation_y();
     dReal dev_a = cfg->noiseDeviation_angle();
 
-    const float CAMERA_HEIGHT = 4;
+    const float CAMERA_HEIGHT = cfg->Camera_Height();
 
     // send the geometry for every camera consecutively to provide the camera setup for all of them
     if (((sendGeomCount++) / 4) % (cfg->sendGeometryEvery() / 4) == 0)
@@ -762,7 +762,7 @@ SSL_WrapperPacket* SSLWorld::generatePacket(int cam_id)
         addFieldLinesArcs(field);
 
         // camera calibration
-        const unsigned FOCAL_LENGTH = 390;
+        const unsigned FOCAL_LENGTH = cfg->Camera_Focal_Length();
 
         SSL_GeometryCameraCalibration* camera = geom->add_calib();
         camera->set_camera_id(cam_id);
@@ -789,8 +789,8 @@ SSL_WrapperPacket* SSLWorld::generatePacket(int cam_id)
     if ((cfg->vanishing()==false) || (rand0_1() > cfg->ball_vanishing()))
     {
         if (visibleInCam(cam_id, x, y)) {
-            const float BALL_RADIUS = 21.5; // mm
-            const float SCALING_LIMIT = 0.9;
+            const float BALL_RADIUS = cfg->BallRadius() * 1000.f;
+            const float SCALING_LIMIT = cfg->Camera_Scaling_Limit();
             SSL_DetectionBall* vball = packet->mutable_detection()->add_balls();
 
             float output_x = randn_notrig(x*1000.0f,dev_x);


### PR DESCRIPTION
### Identify the Bug
[131](https://github.com/RoboCup-SSL/grSim/issues/131)


### Description of the Change

In ssl-vision, balls are always projected onto the field (see bugreport).

While ssl-vision already corrects these positions for the height of the ball itself, this correct is no longer correct as soon as the ball is being chipped.

In order to emulate ssl-visions behavior and make grSim closer to realitiy, we need to trace a ray from the camera to the ball.
The location where this ray would hit the field (corrected by the radius of the ball itself) will be reported by ssl-vision.

This distortion fails as soon as the ball is almost the same height as the camera itself. While the correct approach would be to not show the ball in these cases, I decided on simply bounding the height of the ball (subtracted its already corrected radius) by SCALING_FACTOR * camera_height. This should be correct for sufficiently large camera_heights, as airborne balls normally don't reach the camera.

~As already stated in the commit description, this commit / PR does not include the option to enable / disable this feature via UI. While the code is already ready to get a boolean somewhere and use that boolean to decide if a projection is needed, I have no idea how to properly interact with the UI to get a boolean like that. Instead, it uses a constant that can be modified to get the old behavior.~

_Edit: After some help by @g3force , I was able to implement a proper way of enable / disable this via the UI_

### Alternate Designs

It would have been more correct to discard balls with ball.z ~ camera.z or ball.z > camera.z. As already stated, I don't think that happens particularly often and the boding right now is just to prevent dividing by ~0 in very rare cases (bugs?)

### Possible Drawbacks

Using and publishing the real, correct positions instead of distorting them onto a 2d plane makes it easier for teams to locate the ball. However, as a simulation is only as good as its mapping in reality, having a superoptimal simulator has very little use for advanced teams.

~Having a UI Option instead of flicking a bool in the source code would be nice, but I have no Idea how to properly do that.~
_Done_

### Verification Process

Follow more or less the process outlined in [131](https://github.com/RoboCup-SSL/grSim/issues/131).

You can see that the ball no longer follows a line. Also, if you're able to see the reported packages (i.e. by using protobufs ->DebugString and writing that to stdout), you can see there's no longer a z-coordinate published by grSim.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Grsim's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

-->

More realistic reporting of airborne balls