### PR TITLE
Issue 124 - Added concept of simulation time.

### DIFF
--- a/include/sslworld.h
+++ b/include/sslworld.h
@@ -63,6 +63,7 @@ private:
     QGLWidget* m_parent;
     int framenum;
     dReal last_dt;
+    dReal sim_time = 0;
     QList<SendingPacket*> sendQueue;
     char packet[200];
     char *in_buffer;
@@ -103,7 +104,6 @@ public:
     QUdpSocket *blueStatusSocket,*yellowStatusSocket;
     bool updatedCursor;
     Robot* robots[MAX_ROBOT_COUNT*2];
-    QTime *timer;
     int sendGeomCount;
 public slots:
     void recvActions();

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -298,8 +298,6 @@ SSLWorld::SSLWorld(QGLWidget* parent,ConfigWidget* _cfg,RobotsFomation *form1,Ro
         }
     }
     sendGeomCount = 0;
-    timer = new QTime();
-    timer->start();
     in_buffer = new char [65536];
 
     // initialize robot state
@@ -427,6 +425,7 @@ void SSLWorld::step(dReal dt)
         p->step(dt/ballCollisionTry);
     }
 
+    sim_time += last_dt;
 
     int best_k=-1;
     dReal best_dist = 1e8;
@@ -722,9 +721,8 @@ SSL_WrapperPacket* SSLWorld::generatePacket(int cam_id)
     ball->getBodyPosition(x,y,z);    
     packet->mutable_detection()->set_camera_id(cam_id);
     packet->mutable_detection()->set_frame_number(framenum);    
-    dReal t_elapsed = timer->elapsed()/1000.0;
-    packet->mutable_detection()->set_t_capture(t_elapsed);
-    packet->mutable_detection()->set_t_sent(t_elapsed);
+    packet->mutable_detection()->set_t_capture(sim_time);
+    packet->mutable_detection()->set_t_sent(sim_time);
     dReal dev_x = cfg->noiseDeviation_x();
     dReal dev_y = cfg->noiseDeviation_y();
     dReal dev_a = cfg->noiseDeviation_angle();
@@ -929,7 +927,7 @@ SendingPacket::SendingPacket(SSL_WrapperPacket* _packet,int _t)
 
 void SSLWorld::sendVisionBuffer()
 {
-    int t = timer->elapsed();
+    int t = (int)(sim_time*1000);
     sendQueue.push_back(new SendingPacket(generatePacket(0),t));
     sendQueue.push_back(new SendingPacket(generatePacket(1),t));
     sendQueue.push_back(new SendingPacket(generatePacket(2),t));


### PR DESCRIPTION
### Issue or RFC Endorsed by GrSim's Maintainers

https://github.com/RoboCup-SSL/grSim/issues/124

### Description of the Change

Added concept of simulation time.

- Simulator now keeps track of simulated time.
- SSL packages now report simulated time instead of wall time.

### Alternate Designs

Alternative was to report wall time instead of simulation time which makes simulation speed dependent of cpu performance and load.

### Possible Drawbacks

None expected

### Verification Process

Build grSim after changes.
Compared desired vs measured robot speed from 3rd party software under different fps.

### Release Notes

SSL packages now reports the simulation time which allows for correct readings of simulated speeds.
Otherwise, the speed measured would depend on grSim's fps which would differ from the speed command sent to the robots.
