### PR TITLE
Migrate to travis-ci.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,16 @@ language: cpp
 jobs:
   include:
     - os: linux
-      dist: trusty
-      compiler: clang
-    - os: linux
-      dist: trusty   
-      compiler: gcc
-    - os: linux
       dist: bionic
       compiler: clang
     - os: linux
       dist: bionic
       compiler: gcc
     - os: linux
-      dist: xenial
+      dist: focal
       compiler: clang
     - os: linux
-      dist: xenial
+      dist: focal
       compiler: gcc
     - os: osx
       osx_image: xcode11.3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
+[![Build Status](https://travis-ci.com/RoboCup-SSL/grSim.svg?branch=master)](https://travis-ci.com/RoboCup-SSL/grSim) [![CodeFactor](https://www.codefactor.io/repository/github/robocup-ssl/grsim/badge/master)](https://www.codefactor.io/repository/github/robocup-ssl/grsim/overview/master)
 
-grSim-[![Build Status](https://travis-ci.org/RoboCup-SSL/grSim.svg?branch=master)](https://travis-ci.org/RoboCup-SSL/grSim)[![CodeFactor](https://www.codefactor.io/repository/github/robocup-ssl/grsim/badge/master)](https://www.codefactor.io/repository/github/robocup-ssl/grsim/overview/master)
+grSim
 =======================
 
 [RoboCup Small Size League](https://ssl.robocup.org/) Simulator.


### PR DESCRIPTION
I have migrated all RoboCup-SSL repositories to travis-ci.com now.

This PR updates the URLs.

Additionally, I have changed the Linux distributions for which grSim is built. Ubuntu Trusty (14.04) is out of support since 2019 and Xenial (16.04) will be out of support in April. They hinder usage of more update-to-date APIs.