### PR TITLE
Add dockerfile and make grSim run without a display

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+/bin
+/cmake-build-debug
+/cmake-build-release
+/build
+/.git
+/.idea
+/Dockerfile
+/.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:20.04 AS build
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    git \
+    build-essential \
+    cmake \
+    pkg-config \
+    qt5-default \
+    libqt5opengl5-dev \
+    libgl1-mesa-dev \
+    libglu1-mesa-dev \
+    libprotobuf-dev \
+    protobuf-compiler \
+    libode-dev \
+    libboost-dev
+
+WORKDIR /vartypes
+RUN git clone https://github.com/jpfeltracco/vartypes.git . && \
+    git checkout 2d16e81b7995f25c5ba5e4bc31bf9a514ee4bc42 && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    make install
+
+WORKDIR /grsim
+COPY . .
+RUN mkdir build && \
+    cd build && \
+    cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+    make && \
+    make install
+
+
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive \
+    LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib
+
+RUN apt-get update && apt-get install -y \
+        qt5-default \
+        libqt5opengl5 \
+        libode8 \
+        libprotobuf17
+COPY --from=build /usr/local /usr/local
+
+EXPOSE 20011 30011 30012 10300 10301 10302
+
+ENTRYPOINT ["/usr/local/bin/grSim", "--headless", "-platform", "offscreen"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,13 @@ RUN git clone https://github.com/jpfeltracco/vartypes.git . && \
     make install
 
 WORKDIR /grsim
-COPY . .
+COPY clients /grsim/clients
+COPY cmake /grsim/cmake
+COPY config /grsim/config
+COPY include /grsim/include
+COPY resources /grsim/resources
+COPY src /grsim/src
+COPY CMakeLists.txt README.md LICENSE.md /grsim/
 RUN mkdir build && \
     cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
@@ -41,9 +47,17 @@ RUN apt-get update && apt-get install -y \
         qt5-default \
         libqt5opengl5 \
         libode8 \
-        libprotobuf17
+        libprotobuf17 \
+        # virtual display and VNC server
+        x11vnc xvfb && \
+        apt-get clean -y
 COPY --from=build /usr/local /usr/local
 
-EXPOSE 20011 30011 30012 10300 10301 10302
+RUN useradd -ms /bin/bash default
+COPY /docker-entry.sh .
+RUN chmod 775 /docker-entry.sh
 
-ENTRYPOINT ["/usr/local/bin/grSim", "--headless", "-platform", "offscreen"]
+EXPOSE 20011 30011 30012 10300 10301 10302 5900
+USER default
+WORKDIR /home/default
+ENTRYPOINT ["/docker-entry.sh"]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,13 +23,23 @@ GrSim depends on:
 
 
 
-## Installing from package manager
-### Arch Linux
+## Run from pre-build packages
+### Installing from Arch Linux package manager
 
 A package of grSim is avaliable on the [Arch User Repository](https://aur.archlinux.org/packages/grsim-git/), you can install it with your preferred AUR manager. Using `yay` it can be done with:
 ```bash
-$ sudo yay -S grsim-git
+yay -S grsim-git
 ```
+
+### Using docker image
+You can get latest grSim from [Docker Hub](https://hub.docker.com/r/robocupssl/grsim) with:
+```shell
+docker pull robocupssl/grSim:latest
+```
+
+The container can be run in two flavors:
+1. Headless: `docker run grsim`
+1. With VNC: `docker run -p 5900:5900 -eVNC_PASSWORD=vnc -eVNC_GEOMETRY=1920x1080 grsim vnc`
 
 ## Building and installing from the source code
 

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+grSimArgs="$@"
+
+if [[ "$1" == "vnc" ]]; then
+  echo "Launch in VNC mode"
+  grSimArgs="${@:1}"
+  if [[ -z "${VNC_PASSWORD}" ]]; then
+    VNC_PASSWORD=vncpassword
+  fi
+  if [[ -z "${VNC_GEOMETRY}" ]]; then
+    VNC_GEOMETRY=1280x1024
+  fi
+
+  mkdir ~/.vnc
+  x11vnc -storepasswd "${VNC_PASSWORD}" ~/.vnc/passwd
+
+  cat <<EOF >>~/.xinitrc
+#!/bin/sh
+exec /usr/local/bin/grSim --qwindowgeometry ${VNC_GEOMETRY} $grSimArgs
+EOF
+  chmod 700 ~/.xinitrc
+
+  export X11VNC_CREATE_GEOM="${VNC_GEOMETRY}"
+  exec x11vnc -forever -usepw -display WAIT:cmd=FINDCREATEDISPLAY-Xvfb
+else
+  echo "Launch in headless mode"
+  exec /usr/local/bin/grSim --headless -platform offscreen $grSimArgs
+fi

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,10 +19,16 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 #include "mainwindow.h"
 #include "winmain.h"
 
+void signalHandler( int signum ) {
+    exit(signum);
+}
+
 int main(int argc, char *argv[])
 {
     std::locale::global( std::locale( "" ) );
     
+    signal(SIGINT, signalHandler);
+
     char** argend = argc + argv;
 
     QCoreApplication::setOrganizationName("Parsian");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,16 +29,21 @@ int main(int argc, char *argv[])
     
     signal(SIGINT, signalHandler);
 
-    char** argend = argc + argv;
-
     QCoreApplication::setOrganizationName("Parsian");
     QCoreApplication::setOrganizationDomain("parsian-robotics.com");
     QCoreApplication::setApplicationName("grSim");
     QApplication a(argc, argv);
-    MainWindow w;
 
-    if (std::find(argv, argend, std::string("--headless")) != argend
-        || std::find(argv, argend, std::string("-H")) != argend) {
+    QCommandLineParser parser;
+    parser.setApplicationDescription("RoboCup Small Size League Simulator");
+    parser.addHelpOption();
+    QCommandLineOption headlessOption(QStringList() << "H" << "headless", 
+                                      QCoreApplication::translate("main", "Run without a UI"));
+    parser.addOption(headlessOption);
+    parser.process(a);
+
+    MainWindow w;
+    if (parser.isSet(headlessOption)) {
         // enable headless mode
         w.hide();
         w.setIsGlEnabled(false);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -257,7 +257,10 @@ MainWindow::MainWindow(QWidget *parent)
 
     robotwidget->teamCombo->setCurrentIndex(0);
     robotwidget->robotCombo->setCurrentIndex(0);
-    robotwidget->setPicture(glwidget->ssl->robots[robotIndex(glwidget->Current_robot,glwidget->Current_team)]->img);
+    auto robotPicture = glwidget->ssl->robots[robotIndex(glwidget->Current_robot,glwidget->Current_team)]->img;
+    if(robotPicture != nullptr) {
+        robotwidget->setPicture(robotPicture);
+    }
     robotwidget->id = 0;
 }
 
@@ -337,8 +340,13 @@ QString dRealToStr(dReal a)
 
 void MainWindow::update()
 {
-    if (glwidget->ssl->g->isGraphicsEnabled()) glwidget->updateGL();
-    else glwidget->step();
+    if (glwidget->ssl->isGLEnabled) {
+        glwidget->ssl->g->enableGraphics();
+        glwidget->updateGL();
+    } else {
+        glwidget->ssl->g->disableGraphics();
+        glwidget->step();
+    }
 
     int R = robotIndex(glwidget->Current_robot,glwidget->Current_team);
 

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -386,9 +386,6 @@ void SSLWorld::glinit() {
 }
 
 void SSLWorld::step(dReal dt) {
-    if (!isGLEnabled) g->disableGraphics();
-    else g->enableGraphics();
-
     if (customDT > 0) dt = customDT;
     const auto ratio = m_parent->devicePixelRatio();
     g->initScene(m_parent->width()*ratio,m_parent->height()*ratio,0,0.7,1);


### PR DESCRIPTION
This PR adds a Dockerfile that builds and bundles grSim.

It also contains some necessary tweak to make the container run without requiring a display. The available headless mode was not sufficient, as QT still tried to create a window.

I have not yet tested running it with the UI.

The image is already available on Docker Hub: https://hub.docker.com/r/robocupssl/grsim