### PR TITLE
Shortcut to exit grSim and different robot carcase color for each team

### DIFF
--- a/include/configwidget.h
+++ b/include/configwidget.h
@@ -194,7 +194,11 @@ public:
   DEF_VALUE(double,Double,yellow_team_vanishing)
   DEF_VALUE(std::string, String, plotter_addr)
   DEF_VALUE(int, Int, plotter_port)
-  DEF_VALUE(bool, Bool, plotter)  
+  DEF_VALUE(bool, Bool, plotter)
+
+  DEF_VALUE(std::string, String, ColorRobotBlue)
+  DEF_VALUE(std::string, String, ColorRobotYellow)
+
   void loadRobotSettings(QString team);
 public slots:  
   void loadRobotsSettings();

--- a/include/physics/pobject.h
+++ b/include/physics/pobject.h
@@ -46,6 +46,7 @@ public:
     void getBodyRotation(dMatrix3 r,bool local=false);
     void setVisibility(bool v);
     void setColor(dReal r,dReal g,dReal b);
+    void setColor(const QColor& color);
     void getColor(dReal& r,dReal& g,dReal& b);
     bool getVisibility();
     virtual void setMass(dReal mass);

--- a/src/configwidget.cpp
+++ b/src/configwidget.cpp
@@ -145,7 +145,10 @@ ConfigWidget::ConfigWidget() {
     std::string blueteam = v_BlueTeam->getString();
     geo_vars->removeChild(v_BlueTeam);
 
-    std::string yellowteam = v_YellowTeam->getString();
+    ADD_VALUE(comm_vars, String, ColorRobotBlue, "#0000ff", "Color Robot Blue ")
+    ADD_VALUE(comm_vars, String, ColorRobotYellow, "#ffff00", "Color Robot Yellow")
+
+            std::string yellowteam = v_YellowTeam->getString();
     geo_vars->removeChild(v_YellowTeam);
 
     ADD_ENUM(StringEnum,BlueTeam,blueteam,"Blue Team");

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -71,6 +71,7 @@ bool CGraphics::isGraphicsEnabled()
 }
 
 void CGraphics::setSphereQuality(int q) {sphere_quality = q;}
+
 int CGraphics::loadTexture(QImage* img)
 {
     if (graphicDisabled) return -1;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -249,6 +249,9 @@ MainWindow::MainWindow(QWidget *parent)
     QObject::connect(configwidget->v_YellowTeam.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
     QObject::connect(configwidget->v_BlueTeam.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
 
+    QObject::connect(configwidget->v_ColorRobotBlue.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+    QObject::connect(configwidget->v_ColorRobotYellow.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(restartSimulator()));
+
     //network
     QObject::connect(configwidget->v_VisionMulticastAddr.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectVisionSocket()));
     QObject::connect(configwidget->v_VisionMulticastPort.get(), SIGNAL(wasEdited(VarPtr)), this, SLOT(reconnectVisionSocket()));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -31,6 +31,7 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 #include <QApplication>
 #include <QDir>
 #include <QClipboard>
+#include <QShortcut>
 
 #include <QStatusBar>
 #include <QMessageBox>
@@ -120,6 +121,11 @@ MainWindow::MainWindow(QWidget *parent)
     fileMenu->addAction(takeSnapshotAct);
     fileMenu->addAction(takeSnapshotToClipboardAct);
     fileMenu->addAction(exit);
+
+    QObject::connect(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this),
+                     &QShortcut::activated,
+                     this,
+                     &MainWindow::close);
 
     QMenu *viewMenu = new QMenu("&View");
     menuBar()->addMenu(viewMenu);

--- a/src/physics/pobject.cpp
+++ b/src/physics/pobject.cpp
@@ -53,6 +53,13 @@ void PObject::setColor(dReal r,dReal g,dReal b)
     m_blue = b;
 }
 
+void PObject::setColor(const QColor &color)
+{
+    m_red = color.redF()*4;
+    m_green = color.greenF()*4;
+    m_blue = color.blueF()*4;
+}
+
 void PObject::getColor(dReal& r,dReal& g,dReal& b)
 {
     r = m_red;

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -37,8 +37,8 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 #define ROBOT_GRAY .8
 #define WHEEL_COUNT 4
 
-const QColor ROBOT_BLUE_CHASSIS_COLOR {QColor(10, 10, 10)};
-const QColor ROBOT_YELLOW_CHASSIS_COLOR {QColor(150, 150, 150)};
+QColor ROBOT_BLUE_CHASSIS_COLOR {QColor("#0000ff")};
+QColor ROBOT_YELLOW_CHASSIS_COLOR {QColor("#ffff00")};
 
 SSLWorld* _w;
 dReal randn_notrig(dReal mu=0.0, dReal sigma=1.0);
@@ -152,6 +152,9 @@ SSLWorld::SSLWorld(QGLWidget* parent, ConfigWidget* _cfg, RobotsFormation *form1
     ground = new PGround(cfg->Field_Rad(),cfg->Field_Length(),cfg->Field_Width(),cfg->Field_Penalty_Depth(),cfg->Field_Penalty_Width(),cfg->Field_Penalty_Point(),cfg->Field_Line_Width(),0);
     ray = new PRay(50);
     
+    ROBOT_BLUE_CHASSIS_COLOR = QColor(QString::fromStdString(_cfg->v_ColorRobotBlue->getString()));
+    ROBOT_YELLOW_CHASSIS_COLOR = QColor(QString::fromStdString(_cfg->v_ColorRobotYellow->getString()));
+
     // Bounding walls
     
     const double thick = cfg->Wall_Thickness();


### PR DESCRIPTION

### Description of the Change
Now the robots of yellow and blue team can have different "uniform" colors changing the values of `ROBOT_BLUE_CHASSIS_COLOR` and `ROBOT_YELLOW_CHASSIS_COLOR`.

The color will affect on the texture of the robot.

![Screenshot from 2021-02-05 22-23-18](https://user-images.githubusercontent.com/53309405/107104403-401f1680-6800-11eb-9f00-39124a8dfae0.png)


<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

I still pretend to create a more convenience  way to change it the colors, maybe creating an option on the configurations space would be good.


### Possible Drawbacks

* I am still not sure if I converted the QColor to the color format used on the software correctly [here](https://github.com/RoboCup-SSL/grSim/compare/master...Bollos00:master#diff-b2533f71bc10e2b3aeef4d49943cf283623d354f5a6690b3dc7c89bb3bcf64baR56);

* I do not know if the chances affect the performance of the software;

* It is not simple to change the equips uniform (carcase color);

* The textures of the robots are changed as well.


### Verification Process

Changing the values of `ROBOT_BLUE_CHASSIS_COLOR` and `ROBOT_YELLOW_CHASSIS_COLOR` changes the color of the robots and the simulator continue to work.


### Release Notes

Now the robots of yellow and blue team can have different "uniform" colors.