### PR TITLE
Write ball model parameters to new messages in geometry

### DIFF
--- a/include/configwidget.h
+++ b/include/configwidget.h
@@ -171,6 +171,12 @@ public:
   DEF_VALUE(double,Double,BallLinearDamp)
   DEF_VALUE(double,Double,BallAngularDamp)
   DEF_VALUE(bool,Bool,BallProjectAirborne)
+  DEF_VALUE(double,Double,BallModelTwoPhaseAccSlide)
+  DEF_VALUE(double,Double,BallModelTwoPhaseAccRoll)
+  DEF_VALUE(double,Double,BallModelTwoPhaseKSwitch)
+  DEF_VALUE(double,Double,BallModelChipFixedLossDampingXyFirstHop)
+  DEF_VALUE(double,Double,BallModelChipFixedLossDampingXyOtherHops)
+  DEF_VALUE(double,Double,BallModelChipFixedLossDampingZ)
 
   DEF_VALUE(bool,Bool,SyncWithGL)
   DEF_VALUE(double,Double,DesiredFPS)

--- a/src/configwidget.cpp
+++ b/src/configwidget.cpp
@@ -118,6 +118,14 @@ ConfigWidget::ConfigWidget() {
         ADD_VALUE(ballp_vars,Double,BallLinearDamp,0.004,"Ball linear damping")
         ADD_VALUE(ballp_vars,Double,BallAngularDamp,0.004,"Ball angular damping")
         ADD_VALUE(ballp_vars,Bool,BallProjectAirborne,true,"Project airborne balls")
+  VarListPtr ball_model_vars(new VarList("Models"));
+  ballp_vars->addChild(ball_model_vars);
+    ADD_VALUE(ball_model_vars,Double,BallModelTwoPhaseAccSlide,-14.0,"Straight-two-phase sliding acceleration")
+    ADD_VALUE(ball_model_vars,Double,BallModelTwoPhaseAccRoll,-0.7,"Straight-two-phase rolling acceleration")
+    ADD_VALUE(ball_model_vars,Double,BallModelTwoPhaseKSwitch,0.7,"Straight-two-phase switch factor k")
+    ADD_VALUE(ball_model_vars,Double,BallModelChipFixedLossDampingXyFirstHop,0.6,"Chip-fixed-loss damping in xy-direction for first hop")
+    ADD_VALUE(ball_model_vars,Double,BallModelChipFixedLossDampingXyOtherHops,0.96,"Chip-fixed-loss damping in xy-direction for other hops")
+    ADD_VALUE(ball_model_vars,Double,BallModelChipFixedLossDampingZ,0.42,"Chip-fixed-loss damping in z-direction")
   VarListPtr comm_vars(new VarList("Communication"));
   world.push_back(comm_vars);
     ADD_VALUE(comm_vars,String,VisionMulticastAddr,"224.5.23.2","Vision multicast address")  //SSL Vision: "224.5.23.2"

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -920,6 +920,16 @@ SSL_WrapperPacket* SSLWorld::generatePacket(int cam_id) {
         SSL_GeometryData* geom = pPacket->mutable_geometry();
         SSL_GeometryFieldSize* field = geom->mutable_field();
 
+        auto models = geom->mutable_models();
+        auto straight_two_phase = models->mutable_straight_two_phase();
+        straight_two_phase->set_acc_slide(cfg->BallModelTwoPhaseAccSlide());
+        straight_two_phase->set_acc_roll(cfg->BallModelTwoPhaseAccRoll());
+        straight_two_phase->set_k_switch(cfg->BallModelTwoPhaseKSwitch());
+        auto chip_fixed_loss = models->mutable_chip_fixed_loss();
+        chip_fixed_loss->set_damping_xy_first_hop(cfg->BallModelChipFixedLossDampingXyFirstHop());
+        chip_fixed_loss->set_damping_xy_other_hops(cfg->BallModelChipFixedLossDampingXyOtherHops());
+        chip_fixed_loss->set_damping_z(cfg->BallModelChipFixedLossDampingZ());
+
         // Field general info
         field->set_field_length(CONVUNIT(cfg->Field_Length()));
         field->set_field_width(CONVUNIT(cfg->Field_Width()));


### PR DESCRIPTION
In ssl-vision, I recently introduced ball parameters in the geometry message.

They are required by the autoRefs to correctly configure their ball models and may be useful for other teams as well.
It avoids explicit configuration and/or detection of the vision source, so the autoRefs can correctly run with any simulator, without additional configuration.

This PR just adds the parameters to the config tree and publishes them in the geometry message.
It might be possible to calculate the parameters based on the physics settings, but that was out of scope for me and could be done in a separate PR.