### PR TITLE
Windows GitHub actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - windows-github-actions
   pull_request:
 jobs:
   build-linux:
@@ -25,3 +26,29 @@ jobs:
         run: brew tap robotology/formulae && brew install qt5 protobuf robotology/formulae/ode
       - name: "Build"
         run: mkdir build && cd build && cmake .. && make
+        
+  build-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: make build directory
+      run: mkdir '${{ github.workspace }}/build/'
+
+    - name: Install dependencies # saves / restores cache to avoid rebuilding dependencies
+      uses: lukka/run-vcpkg@v6
+      with:
+        setupOnly: false
+        vcpkgGitCommitId: 99dc49dae7e170c3be63dd097230007f3bb73c4f
+        vcpkgDirectory: c:/vcpkg  # folder must reside in c:\ otherwise qt wont install due to long path errors
+        vcpkgTriplet: x64-windows
+        vcpkgArguments: qt5 ode protobuf
+    
+    - name: Run CMake and build
+      working-directory: ${{ github.workspace }}/build/
+      run: |
+        cmake -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake ..
+        & "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/IDE/devenv.com" /Rebuild "Release|x64" grSim.sln
+        
+
+        

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build/
       run: |
         cmake -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake ..
-        & "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/IDE/devenv.com" /Rebuild "Release|x64" grSim.sln
+        cmake --build . --config Release
         
 
         

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ find_package(Protobuf REQUIRED)
 include_directories(${PROTOBUF_INCLUDE_DIRS})
 list(APPEND libs ${PROTOBUF_LIBRARIES})
 
+set (Protobuf_IMPORT_DIRS ${Protobuf_INCLUDE_DIR})
 protobuf_generate_cpp(PROTO_CPP PROTO_H
     src/proto/grSim_Commands.proto
     src/proto/grSim_Packet.proto

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -136,13 +136,13 @@ The executable will be located on the `bin` directory.
 
 #### Windows
 
-Run CMake to generate a solution in visual studio (note: modify the command below to reflect your vcpkg installation folder).
+Run CMake to generate a solution in visual studio and the build the solution (note: modify the command below to reflect your vcpkg installation folder).
 
 ```bash
 $ cmake -DCMAKE_TOOLCHAIN_FILE=${PATH_TO_VCPKG}\\scripts\\buildsystems\\vcpkg.cmake ..
+$ cmake --build . --config Release
 ```
 
-Then, open the solution file (`grSim.sln`) in Visual Studio, and build project grSim. Make sure to set the project to compile in `Release` version instead of `Debug` version.
 The executable will be located on the `bin` directory.
 
 ### Installing (Linux and Mac OS X)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 #include <QtWidgets/QApplication>
 #include "mainwindow.h"
 #include "winmain.h"
+#include <signal.h>
 
 void signalHandler( int signum ) {
     exit(signum);


### PR DESCRIPTION
### Issue or RFC Endorsed by GrSim's Maintainers

[Issue 145](https://github.com/RoboCup-SSL/grSim/issues/140)


### Description of the Change

Project modified so that it will compile in windows and so that it can be build using github actions.
4 changes added:

- Modified GitHub build action so that windows x64 is also tested on push.
- Defined Protobuf_IMPORT_DIRS in CMakeLists.txt (otherwise vc compiler doesn't find google.protobuf.any.proto)
- Included signals.h in main.cpp (otherwise windows compiler cannot find symbols 'signal' and 'SIGINT'
- Simplified windows installation instructions in INSTALL.md (changes reflect github's build workflow)


### Alternate Designs

None considered

### Possible Drawbacks

None foreseen

### Verification Process

Code was compiled in windows on a personal laptop and through Github actions.
Code successfully compiled for all systems on GitHub.

### Release Notes

N/A


