### PR TITLE
Ball colliding with chassis, but not interfering on kicker/ball contact

### DIFF
--- a/include/physics/pworld.h
+++ b/include/physics/pworld.h
@@ -40,6 +40,7 @@ public:
     void addObject(PObject* o);
     void initAllObjects();
     PSurface* createSurface(PObject* o1,PObject* o2);
+    PSurface* createSurfaceBallChassis(PObject* o1,PObject* o2);
     PSurface* findSurface(PObject* o1,PObject* o2);
     void step(dReal dt=-1);
     void glinit();

--- a/src/physics/pworld.cpp
+++ b/src/physics/pworld.cpp
@@ -155,6 +155,16 @@ PSurface* PWorld::createSurface(PObject* o1,PObject* o2)
     return s;
 }
 
+PSurface* PWorld::createSurfaceBallChassis(PObject* o1,PObject* o2)
+{
+    PSurface *s = new PSurface();
+    s->id1 = o1->geom;
+    s->id2 = o2->geom;
+    surfaces.append(s);
+    sur_matrix[o2->id][o1->id] = surfaces.count() - 1;
+    return s;
+}
+
 PSurface* PWorld::findSurface(PObject* o1,PObject* o2)
 {
     for (int i=0;i<surfaces.count();i++)

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -116,29 +116,32 @@ bool rayCallback(dGeomID o1,dGeomID o2,PSurface* s, int robots_count)
 bool ballCallBack(dGeomID o1,dGeomID o2,PSurface* s, int /*robots_count*/)
 {
     auto body = dGeomGetBody(o1);
-    const dReal *pos_ball = dBodyGetPosition(body);
+    const dReal *posBall = dBodyGetPosition(body);
     body = dGeomGetBody(o2);
-    const dReal *pos_robot = dBodyGetPosition(body);
-    const dReal *dir_robot = dBodyGetRotation(body);
+    const dReal *posRobot = dBodyGetPosition(body);
+    const dReal *dirRobot = dBodyGetRotation(body);
 
     // Get robot angle
     dVector3 v={1,0,0};
     dVector3 axis;
-    dMultiply0(axis,dir_robot,v,4,3,1);
+    dMultiply0(axis,dirRobot,v,4,3,1);
     dReal dot = axis[0];
     dReal length = sqrt(axis[0]*axis[0] + axis[1]*axis[1]);
     dReal absAng = (dReal)(acos((dReal)(dot/length)));
-    dReal angle_robot =  (axis[1] > 0) ? absAng : -absAng;
+    dReal angleRobot =  (axis[1] > 0) ? absAng : -absAng;
 
     // Get angle between robot and ball
-    dReal angle_robot_ball = atan((pos_ball[1] - pos_robot[1])/(pos_ball[0]-pos_robot[0]));
-    angle_robot_ball = (pos_ball[0] > pos_robot[0]) ? angle_robot_ball : M_PI - angle_robot_ball;
+    dReal angleRobotBall = atan((posBall[1] - posRobot[1])/(posBall[0]-posRobot[0]));
+    angleRobotBall = (posBall[0] > posRobot[0]) ? angleRobotBall : M_PI - angleRobotBall;
 
-    dReal angle_kicker = 0.625;
+    // This value is given by the acos(distance_center_kicker/robot_radius)
+    dReal angleKicker = 0.625;
 
-    dReal angle_diff = abs(angle_robot_ball - angle_robot);
+    dReal angleDiff = abs(angleRobotBall - angleRobot);
 
-    return (angle_diff < angle_kicker) ? false : true;
+    // If kicker is facing the ball, the collision with the chassis should not
+    // be considered
+    return (angleDiff < angleKicker) ? false : true;
 }
 
 SSLWorld::SSLWorld(QGLWidget* parent, ConfigWidget* _cfg, RobotsFormation *form1, RobotsFormation *form2) : QObject(parent) {

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -131,17 +131,18 @@ bool ballCallBack(dGeomID o1,dGeomID o2,PSurface* s, int /*robots_count*/)
     dReal angleRobot =  (axis[1] > 0) ? absAng : -absAng;
 
     // Get angle between robot and ball
-    dReal angleRobotBall = atan((posBall[1] - posRobot[1])/(posBall[0]-posRobot[0]));
-    angleRobotBall = (posBall[0] > posRobot[0]) ? angleRobotBall : M_PI - angleRobotBall;
+    dReal angleRobotBall = atan2((posBall[1] - posRobot[1]),(posBall[0]-posRobot[0]));
 
     // This value is given by the acos(distance_center_kicker/robot_radius)
     dReal angleKicker = 0.625;
 
-    dReal angleDiff = abs(angleRobotBall - angleRobot);
+    // Smallest angle diff
+    dReal angleDiff = angleRobotBall - angleRobot;
+    angleDiff += (angleDiff>M_PI) ? -2*M_PI : (angleDiff<-M_PI) ? 2*M_PI : 0;
 
     // If kicker is facing the ball, the collision with the chassis should not
     // be considered
-    return (angleDiff < angleKicker) ? false : true;
+    return (abs(angleDiff) < angleKicker) ? false : true;
 }
 
 SSLWorld::SSLWorld(QGLWidget* parent, ConfigWidget* _cfg, RobotsFormation *form1, RobotsFormation *form2) : QObject(parent) {


### PR DESCRIPTION
### Identify the Bug

#154 

### Description of the Change
- Created a ball with a robot chassis surface to be analyzed for collisions;
- Removed previous ball callback function which was not being utilized;
- Used the ball callback function so the ball still reaches the kicker;
  -  The robot chassis is defined as a full cylinder, so it overlaps with the robot front, if a simple collision check between ball and chassis is performed, the ball would collide with the chassis before reaching the kicker;

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
- I thought about implementing the robot chassis as multiple "faces", so it could better represent the robot geometry, but that approach would be more difficult and possibly reduce the simulator performance, but that should also solve the chassis/chassis collision.
- The PWorld::createSurfaceBallChassis function created may be unnecessary, It was added so at the callback it was not needed to check which object was each;

### Possible Drawbacks
- I'm not sure if the previous ball callback function should be removed or fixed;
- Performance impact was not tested;
- The code quality was not ideal;
- Kicker angle value is hardcoded;
- I believe the force being exerted by the ball on the robot is being ignored since the surface is one way only. I'm still a bit confused about how that works;
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
- Used the grSim wasd commands to move the ball in the robot direction and tried to see if the ball would get inside. Tried different robots and angles;
<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes
- Fixing the ball collision with the robot chassis
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Grsim's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

-->
