### PR TITLE
Use `grSim_RobotReplacement::yellowteam` to determine the team

### DIFF
--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -613,7 +613,7 @@ void SSLWorld::recvActions() {
             if (grSimPacket.has_replacement()) {
                 for (int i=0; i < grSimPacket.replacement().robots_size(); i++) {
                     int team = 0;
-                    if (grSimPacket.commands().has_isteamyellow() && grSimPacket.commands().isteamyellow()) team = 1;
+                    if (grSimPacket.replacement().robots(i).has_yellowteam() && grSimPacket.replacement().robots(i).yellowteam()) team = 1;
 
                     if (!grSimPacket.replacement().robots(i).has_id()) continue;
                     int k = grSimPacket.replacement().robots(i).id();


### PR DESCRIPTION
### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->
#153 

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
With this change, teams are now judged by `grSim_commannds::isteamyellow` instead of `grSim_RobotReplacement::yellowteam` when RobotReplacement. So I changed to using `grSim_RobotReplacement::yellowteam`.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
 - If we set `grSim_commannds::isteamyellow`, we can do `RobotReplacement` correctly.
 - This may be resolved with the migrate to the new standard protocol.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Systems that support the current version will not be able to RobotReplacement correctly.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->
I confirmed that the **yellow** `id` robot was repositioned with this code in our system.

 ```c++
    ssl_protos::grsim::Packet packet{};
    auto r = packet.mutable_replacement()->add_robots();
    r->set_id(id);
    r->set_x(x);
    r->set_y(y);
    r->set_dir(dir);
    r->set_yellowteam(true);

    connection_->send(packet.SerializeAsString());
```

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Grsim's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

-->
N/A