### PR TITLE
Implement robotSpec handling of new protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ bin*/*
 *.swp
 Thumbs.db
 .idea/*
-cmake-build-debug/*
+cmake-build-debug
+cmake-build-release

--- a/config/Parsian.ini
+++ b/config/Parsian.ini
@@ -25,3 +25,11 @@ WheelTangentFriction = 0.8
 WheelPerpendicularFriction = 0.05
 WheelMotorMaximumApplyingTorque= 0.2
 
+MaxLinearKickSpeed=10
+MaxChipKickSpeed=10
+AccSpeedupAbsoluteMax=4
+AccSpeedupAngularMax=50
+AccBrakeAbsoluteMax=4
+AccBrakeAngularMax=50
+VelAbsoluteMax=5
+VelAngularMax=20

--- a/config/ParsianNew.ini
+++ b/config/ParsianNew.ini
@@ -25,3 +25,12 @@ WheelTangentFriction = 0.8
 WheelPerpendicularFriction = 0.05
 WheelMotorMaximumApplyingTorque= 0.2
 
+MaxLinearKickSpeed=10
+MaxChipKickSpeed=10
+AccSpeedupAbsoluteMax=4
+AccSpeedupAngularMax=50
+AccBrakeAbsoluteMax=4
+AccBrakeAngularMax=50
+VelAbsoluteMax=5
+VelAngularMax=20
+

--- a/config/RoboIME2012.ini
+++ b/config/RoboIME2012.ini
@@ -26,3 +26,12 @@ WheelTangentFriction = 0.8
 WheelPerpendicularFriction = 0.05
 WheelMotorMaximumApplyingTorque = 0.2
 
+MaxLinearKickSpeed=10
+MaxChipKickSpeed=10
+AccSpeedupAbsoluteMax=4
+AccSpeedupAngularMax=50
+AccBrakeAbsoluteMax=4
+AccBrakeAngularMax=50
+VelAbsoluteMax=5
+VelAngularMax=20
+

--- a/include/configwidget.h
+++ b/include/configwidget.h
@@ -118,6 +118,14 @@ public:
     double WheelTangentFriction;
     double WheelPerpendicularFriction;
     double Wheel_Motor_FMax;
+    double MaxLinearKickSpeed;
+    double MaxChipKickSpeed;
+    double AccSpeedupAbsoluteMax;
+    double AccSpeedupAngularMax;
+    double AccBrakeAbsoluteMax;
+    double AccBrakeAngularMax;
+    double VelAbsoluteMax;
+    double VelAngularMax;
 };
 
 

--- a/include/robot.h
+++ b/include/robot.h
@@ -40,6 +40,13 @@ class Robot {
     int m_rob_id;
     bool firsttime;
     bool last_state{};
+
+    dReal AccSpeedupAbsoluteMax;
+    dReal AccSpeedupAngularMax;
+    dReal AccBrakeAbsoluteMax;
+    dReal AccBrakeAngularMax;
+    dReal VelAbsoluteMax;
+    dReal VelAngularMax;
 public:    
     ConfigWidget* cfg;
     dSpaceID space;

--- a/include/sslworld.h
+++ b/include/sslworld.h
@@ -70,6 +70,8 @@ private:
     KickStatus lastKickState[TEAM_COUNT][MAX_ROBOT_COUNT]{};
     void processSimControl(const SimulatorCommand &simulatorCommand, SimulatorResponse &simulatorResponse);
     void processRobotControl(const RobotControl &robotControl, RobotControlResponse &robotControlResponse, Team team);
+    void processRobotSpec(const RobotSpecs &robotSpec) const;
+    static void processRobotLimits(const RobotSpecs &robotSpec, RobotSettings *settings);
     static void processMoveCommand(RobotControlResponse &robotControlResponse, const RobotMoveCommand &robotCommand,
                             Robot *robot) ;
     void processTeleportBall(SimulatorResponse &simulatorResponse, const TeleportBall &teleBall) const;
@@ -112,6 +114,7 @@ public:
     bool updatedCursor;
     Robot* robots[MAX_ROBOT_COUNT*2]{};
     int sendGeomCount;
+    bool restartRequired;
 public slots:
     void recvActions();
     void simControlSocketReady();

--- a/src/configwidget.cpp
+++ b/src/configwidget.cpp
@@ -267,4 +267,13 @@ void ConfigWidget::loadRobotSettings(QString team)
     robotSettings.WheelTangentFriction = robot_settings->value("Physics/WheelTangentFriction", 0.8f).toDouble();
     robotSettings.WheelPerpendicularFriction = robot_settings->value("Physics/WheelPerpendicularFriction", 0.05f).toDouble();
     robotSettings.Wheel_Motor_FMax = robot_settings->value("Physics/WheelMotorMaximumApplyingTorque", 0.2f).toDouble();
+    
+    robotSettings.MaxLinearKickSpeed = robot_settings->value("Physics/MaxLinearKickSpeed", 10).toDouble();
+    robotSettings.MaxChipKickSpeed = robot_settings->value("Physics/MaxChipKickSpeed", 10).toDouble();
+    robotSettings.AccSpeedupAbsoluteMax = robot_settings->value("Physics/AccSpeedupAbsoluteMax", 4).toDouble();
+    robotSettings.AccSpeedupAngularMax = robot_settings->value("Physics/AccSpeedupAngularMax", 50).toDouble();
+    robotSettings.AccBrakeAbsoluteMax = robot_settings->value("Physics/AccBrakeAbsoluteMax", 4).toDouble();
+    robotSettings.AccBrakeAngularMax = robot_settings->value("Physics/AccBrakeAngularMax", 50).toDouble();
+    robotSettings.VelAbsoluteMax = robot_settings->value("Physics/VelAbsoluteMax", 5).toDouble();
+    robotSettings.VelAngularMax = robot_settings->value("Physics/VelAngularMax", 20).toDouble();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -452,8 +452,12 @@ void MainWindow::restartSimulator()
     glwidget->ssl = new SSLWorld(glwidget,glwidget->cfg,glwidget->forms[FORMATION_INSIDE_1],glwidget->forms[FORMATION_INSIDE_1]);
     glwidget->ssl->glinit();
     glwidget->ssl->visionServer = visionServer;
+    glwidget->ssl->commandSocket = commandSocket;
     glwidget->ssl->blueStatusSocket = blueStatusSocket;
     glwidget->ssl->yellowStatusSocket = yellowStatusSocket;
+    glwidget->ssl->simControlSocket = simControlSocket;
+    glwidget->ssl->blueControlSocket = blueControlSocket;
+    glwidget->ssl->yellowControlSocket = yellowControlSocket;
 }
 
 void MainWindow::ballMenuTriggered(QAction* act)
@@ -595,6 +599,9 @@ void MainWindow::recvActions()
 void MainWindow::simControlSocketReady()
 {
     glwidget->ssl->simControlSocketReady();
+    if (glwidget->ssl->restartRequired) {
+        restartSimulator();
+    }
 }
 
 void MainWindow::blueControlSocketReady()

--- a/src/proto/ssl_simulation_config.proto
+++ b/src/proto/ssl_simulation_config.proto
@@ -49,8 +49,8 @@ message RobotSpecs {
     optional float max_linear_kick_speed = 7;
     // Max chip kick speed [m/s] (unset = unlimited)
     optional float max_chip_kick_speed = 8;
-    // Width of the dribbler [m] (implicitly defines the distance from robot center to dribbler and opening angle)
-    optional float dribbler_width = 9;
+    // Distance from robot center to dribbler [m] (implicitly defines the opening angle and dribbler width)
+    optional float center_to_dribbler = 9;
     // Movement limits
     optional RobotLimits limits = 10;
     // Wheel angle configuration


### PR DESCRIPTION
This PR adds support for receiving the robotSpecs from the new protocol.

It overwrites existing robot configs and adds some new ones for limiting robot speed and kick speed.