### PR TITLE
fix division by zero bug on robot spec handling

### DIFF
--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -452,6 +452,8 @@ void Robot::setSpeed(int i,dReal s)
 
 void Robot::setSpeed(dReal vx, dReal vy, dReal vw)
 {
+    dReal _DEG2RAD = M_PI / 180.0;
+
     dReal v = sqrt(vx * vx + vy * vy);
     if (v > VelAbsoluteMax) {
         vx *= VelAbsoluteMax / v;
@@ -469,8 +471,20 @@ void Robot::setSpeed(dReal vx, dReal vy, dReal vw)
     if (abs(a) > aLimit) {
         a = copysign(aLimit, a);
         dReal new_v = cv + a * cfg->DeltaTime() * 2;
-        vx *= new_v / v;
-        vy *= new_v / v;
+        if (v > 0) {
+            vx *= new_v / v;
+            vy *= new_v / v;
+        } else {
+            // convert global to local
+            dReal k, angle;
+            angle = getDir(k);
+            angle *= _DEG2RAD;
+            dReal cvx = cvv[0]*cos(angle) + cvv[1]*sin(angle);
+            dReal cvy = -cvv[0]*sin(angle) + cvv[1]*cos(angle);
+
+            vx = cvx * (new_v / cv);
+            vy = cvy * (new_v / cv);
+        }
     }
 
     const dReal* cvvw = dBodyGetAngularVel(chassis->body);
@@ -483,7 +497,6 @@ void Robot::setSpeed(dReal vx, dReal vy, dReal vw)
     }
     
     // Calculate Motor Speeds
-    dReal _DEG2RAD = M_PI / 180.0;
     dReal motorAlpha[4] = {cfg->robotSettings.Wheel1Angle * _DEG2RAD, cfg->robotSettings.Wheel2Angle * _DEG2RAD, cfg->robotSettings.Wheel3Angle * _DEG2RAD, cfg->robotSettings.Wheel4Angle * _DEG2RAD};
 
     dReal dw1 =  (1.0 / cfg->robotSettings.WheelRadius) * (( (cfg->robotSettings.RobotRadius * vw) - (vx * sin(motorAlpha[0])) + (vy * cos(motorAlpha[0]))) );

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -476,8 +476,8 @@ void Robot::setSpeed(dReal vx, dReal vy, dReal vw)
             vy *= new_v / v;
         } else {
             // convert global to local
-            dReal k, angle;
-            angle = getDir(k);
+            dReal angle;
+            angle = getDir();
             angle *= _DEG2RAD;
             dReal cvx = cvv[0]*cos(angle) + cvv[1]*sin(angle);
             dReal cvy = -cvv[0]*sin(angle) + cvv[1]*cos(angle);


### PR DESCRIPTION
### Identify the Bug

#160 

### Description of the Change

Handle the case when acceleration is higher than the limit and sent speed is zero by using the robot current speed as proposed @g3force 

### Alternate Designs

I tried setting the limits directly to the wheel sent speeds, but this solution is simpler and requires less conversions

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

I've tested sending a robot speed for a fixed number of steps, then set the speed to zero. This test was done for different robot angles.

### Release Notes

Not applicable
