### PR TITLE
Update document for using docker image.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,12 +34,15 @@ yay -S grsim-git
 ### Using docker image
 You can get latest grSim from [Docker Hub](https://hub.docker.com/r/robocupssl/grsim) with:
 ```shell
-docker pull robocupssl/grSim:latest
+docker pull robocupssl/grsim:latest
 ```
 
 The container can be run in two flavors:
-1. Headless: `docker run grsim`
-1. With VNC: `docker run -p 5900:5900 -eVNC_PASSWORD=vnc -eVNC_GEOMETRY=1920x1080 grsim vnc`
+1. Headless: `docker run robocupssl/grsim`
+1. With VNC: `docker run --net=host -eVNC_PASSWORD=vnc -eVNC_GEOMETRY=1920x1080 robocupssl/grsim vnc`
+    1. Then launch your VNC client app (e.g. [Remmina](https://remmina.org/)).
+    1. Connect to `localhot:5900`.
+    1. Enter a password (default:`vnc`) to login.
 
 ## Building and installing from the source code
 


### PR DESCRIPTION
### Description of the Change

This PR contains below changes for the installation document:

- Fix typo of docker image name `robocupssl/grsim`.
- Fix the docker command to use `host` network.
  - This enable to the grsim publish vision data on other ports (e.g. 10020)
- Add more explanations about using docker image with VNC.

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes

N/A

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Grsim's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

-->