### PR TITLE
Fix CI `build-windows` : Update vcpkg to `2022.10.19` release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: lukka/run-vcpkg@v6
         with:
           setupOnly: false
-          vcpkgGitCommitId: 99dc49dae7e170c3be63dd097230007f3bb73c4f
+          vcpkgGitCommitId: 94ce0dab56f4d8ba6bd631ba59ed682b02d45c46
           vcpkgDirectory: c:/vcpkg  # folder must reside in c:\ otherwise qt wont install due to long path errors
           vcpkgTriplet: x64-windows
           vcpkgArguments: qt5 ode protobuf


### PR DESCRIPTION
### Identify the Bug

CI to check build on windows fails with error below (see full log at https://github.com/RoboCup-SSL/grSim/actions/runs/3413239297/jobs/5679721865

<details>
<summary>Error found in build log for latest commit </summary>

````sh
  Running 'vcpkg remove --outdated --recurse ' in directory 'c:\vcpkg' ...
  There are no outdated packages.
  Using triplet 'x64-windows'.
  Set the environment variable 'RUNVCPKG_VCPKG_TRIPLET' to value: x64-windows
  Set the output variable 'RUNVCPKG_VCPKG_TRIPLET_OUT' to value: x64-windows
  Running 'vcpkg install --recurse qt5 ode protobuf --triplet x64-windows --clean-after-build' in directory 'c:\vcpkg' ...
  Computing installation plan...
  The following packages will be built and installed:
    * brotli[core]:x64-windows -> 1.0.9
    * bzip2[core]:x64-windows -> 1.0.8#1
    * double-conversion[core]:x64-windows -> 3.1.5
    * egl-registry[core]:x64-windows -> 2020-02-20
    * freeglut[core]:x64-windows -> 3.2.1-4
    * freetype[brotli,bzip2,core,png,zlib]:x64-windows -> 2.10.4
    * harfbuzz[core]:x64-windows -> 2.7.4
    * icu[core]:x64-windows -> 67.1#8
    * jasper[core]:x64-windows -> 2.0.20
    * libjpeg-turbo[core]:x64-windows -> 2.0.6
    * liblzma[core]:x64-windows -> 5.2.5#2
    * libpng[core]:x64-windows -> 1.6.37#14
    * libpq[core,openssl,zlib]:x64-windows -> 12.2#11
    * libwebp[core,nearlossless,simd,unicode]:x64-windows -> 1.1.0#1
      ode[core]:x64-windows -> 0.16.1
    * opengl[core]:x64-windows -> 0.0#8
    * openssl[core]:x64-windows -> 1.1.1i
    * pcre2[core]:x64-windows -> 10.35#2
      protobuf[core]:x64-windows -> 3.14.0#1
      qt5[activeqt,core,declarative,essentials,imageformats,multimedia,networkauth,quickcontrols2,svg,tools]:x64-windows -> 5.15.2
    * qt5-activeqt[core]:x64-windows -> 5.15.2
    * qt5-base[core]:x64-windows -> 5.15.2#1
    * qt5-declarative[core]:x64-windows -> 5.15.2
    * qt5-imageformats[core]:x64-windows -> 5.15.2
    * qt5-multimedia[core]:x64-windows -> 5.15.2
    * qt5-networkauth[core]:x64-windows -> 5.15.2
    * qt5-quickcontrols2[core]:x64-windows -> 5.15.2
    * qt5-svg[core]:x64-windows -> 5.15.2
    * qt5-tools[core]:x64-windows -> 5.15.2
    * sqlite3[core]:x64-windows -> 3.33.0
    * tiff[core]:x64-windows -> 4.1.0#1
    * zlib[core]:x64-windows -> 1.2.11#9
    * zstd[core]:x64-windows -> 1.4.5#1
  Additional packages (*) will be modified to complete this operation.
  Detecting compiler hash for triplet x64-windows...
  Could not locate cached archive: C:\Users\runneradmin\AppData\Local\vcpkg\archives\d0\d0792146305458a654a3118d1419e178a6c5333b.zip
  Could not locate cached archive: C:\Users\runneradmin\AppData\Local\vcpkg\archives\b4\b42ffdd049c46c0df3edc09acab088988e97ac2e.zip
  Could not locate cached archive: C:\Users\runneradmin\AppData\Local\vcpkg\archives\6d\6dbb37896f51f8190360ef618079b8e8eaef6240.zip
  Could not locate cached archive: C:\Users\runneradmin\AppData\Local\vcpkg\archives\46\468cb8f24c3d8e66cd2a351f25cb37ff4a4e45a1.zip
  Could not locate cached archive: C:\Users\runneradmin\AppData\Local\vcpkg\archives\9a\9acc5ea8c2a6d8468673496bac4c59c0a034a3fe.zip
  Could not locate cached archive: C:\Users\runneradmin\AppData\Local\vcpkg\archives\60\60423e6fb26fc1b8db3d49e7871882a11b0e4389.zip
  Could not locate cached archive: C:\Users\runneradmin\AppData\Local\vcpkg\archives\ff\ffd57bc5d4c64b1517bc5e4647a5d60ddebb2d01.zip
  Could not locate cached archive: C:\Users\runneradmin\AppData\Local\vcpkg\archives\2b\2bc3565e7dd3ef6ec802acf31d72978572fe4e75.zip
  -- Downloading https://mirror.selfnet.de/msys2/mingw/i686/mingw-w64-i686-pkg-config-0.29.2-2-any.pkg.tar.zst... Failed. Status: 22;"HTTP response code said error"
  -- Downloading https://mirrors.sjtug.sjtu.edu.cn/msys2/mingw/i686/mingw-w64-i686-pkg-config-0.29.2-2-any.pkg.tar.zst -> msys-mingw-w64-i686-pkg-config-0.29.2-2-any.pkg.tar.zst...
  -- Downloading https://mirrors.sjtug.sjtu.edu.cn/msys2/mingw/i686/mingw-w64-i686-pkg-config-0.29.2-2-any.pkg.tar.zst... Failed. Status: 22;"HTTP response code said error"
  CMake Error at scripts/cmake/vcpkg_download_distfile.cmake:184 (message):
        
        Failed to download file.
        If you use a proxy, please set the HTTPS_PROXY and HTTP_PROXY environment
        variables to "***your-proxy-ip-address:port/".
        
        If error with status 4 (Issue #15434),
        try setting "***your-proxy-ip-address:port/".
        
        Otherwise, please submit an issue at https://github.com/Microsoft/vcpkg/issues
  
  Call Stack (most recent call first):
    scripts/cmake/vcpkg_acquire_msys.cmake:90 (vcpkg_download_distfile)
    scripts/cmake/vcpkg_acquire_msys.cmake:138 (msys_package_download)
    scripts/cmake/vcpkg_find_acquire_program.cmake:446 (vcpkg_acquire_msys)
    scripts/cmake/vcpkg_fixup_pkgconfig.cmake:112 (vcpkg_find_acquire_program)
    ports/brotli/portfile.cmake:25 (vcpkg_fixup_pkgconfig)
    scripts/ports.cmake:133 (include)
  
  
  Error: Building package brotli:x64-windows failed with: BUILD_FAILED
  Please ensure you're using the latest portfiles with `.\vcpkg update`, then
  submit an issue at https://github.com/Microsoft/vcpkg/issues including:
    Package: brotli:x64-windows
    Vcpkg version: 2021-01-13-768d8f95c9e752603d2c5901c7a7c7fbdb08af35
  
  Additionally, attach any relevant sections from the log files above.

````
</details>

Maybe related to #162

### Description of the Change

This have been fixed on upstream (vcpkg 2021.04.30 release). We can get green CI by updating vcpkg to recent release.  
This PR simply updates vcpkg from microsoft/vcpkg@99dc49dae7e170c3be63dd097230007f3bb73c4f (on Feb 20, 2021) to microsoft/vcpkg@94ce0dab56f4d8ba6bd631ba59ed682b02d45c46 (latest release [`2022.10.19`](https://github.com/microsoft/vcpkg/releases/tag/2022.10.19)).

Note: I found a similar issue on vcpkg repo microsoft/vcpkg#23828 and the answer was "just update vcpkg to latest version".

### Alternate design

N/A for vcpkg. We would be better to check new release 
There are newer version of `lukka/run-vcpkg`. However, the usage has changed significantly, and the build did not pass at present with just bumping the version. So I skipped the update this time.

### Possible Drawbacks

N/A

### Verification Process

Wait for an hour and check if the job succeed. The build took a little over 2 hours.  
Check the log on my fork if necessary. : https://github.com/kkimurak/grSim/actions/runs/3433797219

### Release Notes

N/A