### PR TITLE
Set different positions when turning off robots with the robocup ssl protocol to avoid collisions between robots.

### DIFF
--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -842,8 +842,9 @@ void SSLWorld::processTeleportRobot(const TeleportRobot &teleBot, Robot *robot) 
     if (teleBot.has_present()) {
         robot->on = teleBot.present();
         if(!teleBot.present()) {
-            // Move it out of the field
-            robot->setXY(1e6, 1e6);
+            // Move it out of the field.
+            // Set different x and y to avoid collisions of the robots.
+            robot->setXY(1e6 * teleBot.id().id(), 1e6 * teleBot.id().team());
         }
     }
 }


### PR DESCRIPTION

### Identify the Bug

This PR fixes #185 

### Description of the Change

When executing the `present=false` process, all robots are placed in different locations.
